### PR TITLE
Make it clearer that it supports two different DBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Explorer depends on a trusted full node.
 
 ![Architecture](img/Architecture.png)
 
-BTCPay server saves its data into SQLite DB of postgres.
+BTCPay server saves its data into either a SQLite or a PostgreSQL database.
 
 ## Where to go next?
 


### PR DESCRIPTION
make it more explicitly clear that we support both PostgreSQL and SQLite