### PR TITLE
Fixing Magento > Magneto typo in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This solution is for you if:
 
 * [Drupal](Drupal.md)
 * [WooCommerce](WooCommerce.md)
-* [Magneto](https://github.com/btcpayserver/magento-plugin)
+* [Magento](https://github.com/btcpayserver/magento-plugin)
 * [PrestaShop](https://github.com/btcpayserver/prestashop-plugin)
 * [Custom integration](CustomIntegration.md)
 


### PR DESCRIPTION
Fixing the typo in README.md.