### PR TITLE
Docs structure change surrounding Apps

### DIFF
--- a/Apps.md
+++ b/Apps.md
@@ -1,5 +1,5 @@
 # BTCPay Server Apps
-The primary purpose of BTCPay Server is to remove dependencies on trusted third-parties. The Apps are built in applications that obsolete central-authorities and allow users an easy way to extend the [use case](UseCase.md) of the software. Users can self-host all sorts of customizable applications that work out of the box. 
+The primary purpose of BTCPay Server is to remove dependencies on trusted third-parties. The Apps are built in applications that obsolete central-authorities and allow users an easy way to extend the [use case](UseCase.md) of the software. Users can self-host all sorts of customizable applications that work out of the box.
 
 To create an app, go to Apps > Create a new app. Apps are store-dependent, which means that each app needs to be connected to a store.
 
@@ -11,6 +11,12 @@ The web-based PoS app allows users with brick and mortar stores to readily accep
 Adding new products is easy. The app has a shopping cart feature, tips, custom payment options and more.
 
 Point of sale app can also be used for receiving donations or even as a small e-shop, depending on the customizations applied.
+
+## Crowdfunding App
+
+Crowdfunding is an application which you can launch from BTCPay Server interface that allows you to create a self-hosted funding campaign, similar to Kickstarter or Indiegogo. Unlike traditional crowdfunding platforms, the creator of the campaign is the owner of the platform. Funds go directly to the creator’s wallet without any fees.
+
+[![BTCPay Crowdfunding](https://img.youtube.com/vi/tFbfyneDj88/mqdefault.jpg)](https://www.youtube.com/watch?v=tFbfyneDj88 "BTCPay crowdfunding")
 
 ## Payment Button
 Easily-embeddable HTML and highly-customizable payment buttons allow users to receive tips and donations. Online stores can also integrate payment buttons. When a site visitor clicks on the button, BTCPay displays the invoice.

--- a/Crowdfunding.md
+++ b/Crowdfunding.md
@@ -1,0 +1,6 @@
+## Crowdfunding App
+
+Crowdfunding is an application which you can launch from BTCPay Server interface that allows you to create a self-hosted funding campaign, similar to Kickstarter or Indiegogo. Unlike traditional crowdfunding platforms, the creator of the campaign is the owner of the platform. Funds go directly to the creator’s wallet without any fees.
+
+
+[![BTCPay Crowdfunding](https://img.youtube.com/vi/tFbfyneDj88/mqdefault.jpg)](https://www.youtube.com/watch?v=tFbfyneDj88 "BTCPay crowdfunding")

--- a/PointofSale.md
+++ b/PointofSale.md
@@ -1,0 +1,8 @@
+## Point of Sale App
+The web-based PoS app allows users with brick and mortar stores to readily accept cryptocurrencies without fees or a third-party, directly to their wallet. The PoS can be displayed easily on tablets or any other devices which support web browsing. Users can easily create a homescreen shortcut for a quick access to the web-app.
+
+![BTCPay Pos](img/BTCPayPointOfSale1.jpg)
+
+Adding new products is easy. The app has a shopping cart feature, tips, custom payment options and more.
+
+Point of sale app can also be used for receiving donations or even as a small e-shop, depending on the customizations applied.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,11 @@ If an invoice is paid while your BTCPay server is down, the software will automa
 
 * [Internal Wallet](Wallet.md)
 * [Apps](Apps.md)
+  * [Point of Sale](PointofSale.md)
+  * [Crowdfunding](Crowdfunding.md)
+  * [Payment Button](Apps.md#payment-button)
 * [Lightning Network](LightningNetwork.md)
 * [Accounting](Accounting.md)
-
-### Apps
-
-* [Point of Sale](PointofSale.md)
-* [Crowdfunding](Crowdfunding.md)
-* [View All](Apps.md)
 
 ### Integrations
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ If an invoice is paid while your BTCPay server is down, the software will automa
 ### Apps
 
 * [Point of Sale](PointofSale.md)
-* [Crowd Funding](CrowdFunding.md)
+* [Crowdfunding](Crowdfunding.md)
+* [View All](Apps.md)
 
 ### Integrations
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The data is shared only between two parties - the buyer and a seller. Other paym
 * No third-party
 * Can easily be re-deployed
 
-BTCPay does not have a central point of failure since nobody is controlling it except for the user running it. If run on the cloud server, the hosting providers can potentially censor users by suspending hosting accounts or disabling access to virtual machines. This is always a risk for anyone using a hosting provider. Since no private keys are stored on the server, a censored individual can easily re-deploy the server with another host. Your coins are always inside your wallet. 
+BTCPay does not have a central point of failure since nobody is controlling it except for the user running it. If run on the cloud server, the hosting providers can potentially censor users by suspending hosting accounts or disabling access to virtual machines. This is always a risk for anyone using a hosting provider. Since no private keys are stored on the server, a censored individual can easily re-deploy the server with another host. Your coins are always inside your wallet.
 If an invoice is paid while your BTCPay server is down, the software will automatically determine and notify the merchant of offline invoice payments when your server is back up. If a hosting provider suspends the server, and there was no proper backup, server settings and invoice data may be lost, but on-chain payments are always in your wallet. For ultimate censorship-resistance, users should run [BTCPay on their own hardware](HardwareDeployment.md).
 ## Documentation
 
@@ -53,7 +53,7 @@ If an invoice is paid while your BTCPay server is down, the software will automa
 * [Getting Started](GettingStarted.md)
 * [BTCPay vs other processors](BTCPayVsOthers.md)
 * [Try it Out](TryItOut.md)
-    
+
 ## Deployment
 
 * [Choosing a Deployment Method](Deployment.md)
@@ -74,6 +74,11 @@ If an invoice is paid while your BTCPay server is down, the software will automa
 * [Apps](Apps.md)
 * [Lightning Network](LightningNetwork.md)
 * [Accounting](Accounting.md)
+
+### Apps
+
+* [Point of Sale](PointofSale.md)
+* [Crowd Funding](CrowdFunding.md)
 
 ### Integrations
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ If an invoice is paid while your BTCPay server is down, the software will automa
   * [Point of Sale](PointofSale.md)
   * [Crowdfunding](Crowdfunding.md)
   * [Payment Button](Apps.md#payment-button)
+  * [Lightning Network Apps](Apps.md#lightning-network-apps-lapps)
 * [Lightning Network](LightningNetwork.md)
 * [Accounting](Accounting.md)
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -26,14 +26,11 @@
 
 * [Internal Wallet](Wallet.md)
 * [Apps](Apps.md)
+  * [Point of Sale](PointofSale.md)
+  * [Crowdfunding](Crowdfunding.md)
+  * [Payment Button](Apps.md#payment-button)
 * [Lightning Network](LightningNetwork.md)
 * [Accounting](Accounting.md)
-
-### Apps
-
-* [Point of Sale](PointofSale.md)
-* [Crowdfunding](Crowdfunding.md)
-* [View All](Apps.md)
 
 ### Integrations
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -29,6 +29,7 @@
   * [Point of Sale](PointofSale.md)
   * [Crowdfunding](Crowdfunding.md)
   * [Payment Button](Apps.md#payment-button)
+  * [Lightning Network Apps](Apps.md#lightning-network-apps-lapps)
 * [Lightning Network](LightningNetwork.md)
 * [Accounting](Accounting.md)
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -7,7 +7,7 @@
 * [Getting Started](GettingStarted.md)
 * [BTCPay vs other processors](BTCPayVsOthers.md)
 * [Try it Out](TryItOut.md)
-    
+
 ## Deployment
 
 * [Choosing a Deployment Method](Deployment.md)
@@ -28,6 +28,11 @@
 * [Apps](Apps.md)
 * [Lightning Network](LightningNetwork.md)
 * [Accounting](Accounting.md)
+
+### Apps
+
+* [Point of Sale](PointofSale.md)
+* [Crowd Funding](CrowdFunding.md)
 
 ### Integrations
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -32,7 +32,8 @@
 ### Apps
 
 * [Point of Sale](PointofSale.md)
-* [Crowd Funding](CrowdFunding.md)
+* [Crowdfunding](Crowdfunding.md)
+* [View All](Apps.md)
 
 ### Integrations
 


### PR DESCRIPTION
- Adds Crowdfunding.md and PointofSale.md pages. 
- Add Crowdfunding to Apps.md
- Add subcats to Apps under Features linking to new pages and App.md anchors

The goal of this PR is to structure App docs in a way that they can be expanded upon later. PoS and CF likely need their own page sections for setup guides, troubleshooting, FAQ, and external links. This relieves congestion on Apps.md, so it can act as a quick summary of BTCPay Apps, with quick links added later to the extended documentation. 

PR related to issues: #159  #158 

Possible points of criticism:
- Naming of MD files
- Crowdfunding vs Crowdfund 
- New pages are currently just stubs and redundant
- Apps.md can handle all the information just fine as it is. 
- Breaks current structure. All walk-throughs and FAQ are grouped together.



