### PR TITLE
Add another way to solve reindex-chainstate

### DIFF
--- a/FAQ/FAQ-Synchronization.md
+++ b/FAQ/FAQ-Synchronization.md
@@ -117,7 +117,12 @@ rm -rf /var/lib/docker/volumes/generated_bitcoin_datadir/_data
 mkdir /var/lib/docker/volumes/generated_bitcoin_datadir/_data
 btcpay-up.sh
 ```
+If the above command did not solve your issue, try:
 
+```bash
+docker exec -ti btcpayserver_bitcoind /bin/bash
+bitcoind -reindex-chainstate
+```
 ### Cause 2: You do not have enough RAM
 
 Check your RAM:


### PR DESCRIPTION
This is apparently another way to tackle reindex-chainstate problem with corrupted nodes.
I have not tested it, but a community member cr0wn_gh0ul reported it worked for their use-case.

It's untested, so requires a review and approval of someone more familiar with the problem.