### PR TITLE
Replace store link, remove button demo

### DIFF
--- a/Translate.md
+++ b/Translate.md
@@ -13,7 +13,7 @@ If you have any questions about translating, join the [#Translations channel](ht
   * Step 2: Find Your Language-Country Code
   * Step 3: New Language Translation
   * Translation Tips
-  * View:  [Checkout Page](https://store.demo.btcpayserver.org/) For Reference
+  * View:  [Checkout Page](https://store.btcpayserver.org/) For Reference
 
 ----
 
@@ -64,5 +64,5 @@ They should not be translated, but they need to remain in the correct place in y
 
 Need context for a string?
 
-Visit the BTCPay Server demo store [checkout page](https://store.demo.btcpayserver.org/). 
+Visit the BTCPay Server demo store [checkout page](https://store.btcpayserver.org/). 
 

--- a/TryItOut.md
+++ b/TryItOut.md
@@ -40,7 +40,6 @@ See the [What's Next](https://docs.btcpayserver.org/getting-started/whatsnext) p
 
 To see BTCPay in action, visit our demo apps and stores or check out some of the stores using BTCPay in production.
 
-* [BTCPay Demo Store](https://store.demo.btcpayserver.org/)
+* [BTCPay Demo Store](https://store.btcpayserver.org/)
 * [Point of Sale Demo](https://mainnet.demo.btcpayserver.org/apps/87kj5yKay8mB4UUZcJhZH5TqDKMD3CznjwLjiu1oYZXe/pos)
-* [Payment Button Demo](https://store.demo.btcpayserver.org/?page_id=44)
 * [In-production stores](https://bitcoinshirt.co/btcpay-stores/)

--- a/UseCase.md
+++ b/UseCase.md
@@ -28,7 +28,7 @@ Want to give it a try? Here is an up-to-date list of [third-party hosts](ThirdPa
 
 If you're a merchant running an e-commerce business, you can easily [deploy BTCPay](https://docs.btcpayserver.org/deployment) and connect it to your store via [integration plugins](https://docs.btcpayserver.org/integrations/) in just a few clicks.
 
-BTCPay checkout is no different to any other payment gateway. Your customer gets an invoice. They pay it by scanning a QR code or by copy-pasting the amount and the address. When their payment is confirmed, you will be notified via your e-commerce CMS, and you can ship the item. Take a look at [our demo online store](https://store.demo.btcpayserver.org/).
+BTCPay checkout is no different to any other payment gateway. Your customer gets an invoice. They pay it by scanning a QR code or by copy-pasting the amount and the address. When their payment is confirmed, you will be notified via your e-commerce CMS, and you can ship the item. Take a look at [our demo online store](https://store.btcpayserver.org/).
 
 ### Physical Store
 


### PR DESCRIPTION
Closes #330 
And on top of that removes demo button links, until we have a new demo button page on which @vswee is working on. I've added a comment for this one in #