### PR TITLE
Set BTCPAY_ENABLE_SSH=true in Raspberry Pi deployment guides

### DIFF
--- a/RPi3.md
+++ b/RPi3.md
@@ -223,6 +223,7 @@ export BTCPAYGEN_CRYPTO1="btc"
 export BTCPAYGEN_REVERSEPROXY="nginx"
 export BTCPAYGEN_LIGHTNING="lnd"
 export BTCPAYGEN_ADDITIONAL_FRAGMENTS="opt-save-storage-xs;opt-save-memory"
+export BTCPAY_ENABLE_SSH=true
 ```
 
 If you want to use multiple hostnames, add them via the optional `BTCPAY_ADDITIONAL_HOSTS` variable:

--- a/RPi4.md
+++ b/RPi4.md
@@ -231,6 +231,7 @@ export BTCPAYGEN_LIGHTNING="lnd"
 export BTCPAYGEN_REVERSEPROXY="nginx"
 export BTCPAYGEN_ADDITIONAL_FRAGMENTS="opt-more-memory"
 export BTCPAYGEN_EXCLUDE_FRAGMENTS="opt-add-tor"
+export BTCPAY_ENABLE_SSH=true
 ```
 
 If you want to use multiple hostnames, add them via the optional `BTCPAY_ADDITIONAL_HOSTS` variable:


### PR DESCRIPTION
<img width="367" alt="Screen Shot 2019-10-11 at 14 05 51" src="https://user-images.githubusercontent.com/232186/66625748-88402000-ec30-11e9-8e5e-4e4c6df4a6d4.png">