### PR TITLE
Allow ssh connections from docker network on RPI

### DIFF
--- a/RPi3.md
+++ b/RPi3.md
@@ -99,14 +99,15 @@ Install UFW:
 sudo apt install ufw
 ```
 
-This command allows SSH connections from your LAN only.<br/>
-**⚠️ Replace `192.168.1.0` with your own subnet:**
+This command allows SSH connections from internal networks only:
 ```bash
-# local network
-sudo ufw allow from 192.168.1.0/24 to any port 22
-
-# docker network, required for maintenance features
-sudo ufw allow from 172.18.0.0/24 to any port 22
+sudo ufw allow from 10.0.0.0/8 to any port 22 proto tcp
+sudo ufw allow from 172.16.0.0/12 to any port 22 proto tcp
+sudo ufw allow from 192.168.0.0/16 to any port 22 proto tcp
+sudo ufw allow from 169.254.0.0/16 to any port 22 proto tcp
+sudo ufw allow from fc00::/7 to any port 22 proto tcp
+sudo ufw allow from fe80::/10 to any port 22 proto tcp
+sudo ufw allow from ff00::/8 to any port 22 proto tcp
 ```
 
 These ports need to be accessible from anywhere (The default subnet is 'any' unless you specify one):

--- a/RPi3.md
+++ b/RPi3.md
@@ -102,7 +102,11 @@ sudo apt install ufw
 This command allows SSH connections from your LAN only.<br/>
 **⚠️ Replace `192.168.1.0` with your own subnet:**
 ```bash
+# local network
 sudo ufw allow from 192.168.1.0/24 to any port 22
+
+# docker network, required for maintenance features
+sudo ufw allow from 172.18.0.0/24 to any port 22
 ```
 
 These ports need to be accessible from anywhere (The default subnet is 'any' unless you specify one):

--- a/RPi4.md
+++ b/RPi4.md
@@ -187,7 +187,11 @@ This command allows SSH connections from your LAN only.<br/>
 **⚠️ Replace `192.168.1.0` with your own subnet:**
 
 ```bash
-sudo ufw allow from 192.168.1.0/24 to any port 22
+# local network
+ufw allow from 192.168.1.0/24 to any port 22
+
+# docker network, required for maintenance features
+ufw allow from 172.18.0.0/24 to any port 22
 ```
 
 These ports need to be accessible from anywhere (The default subnet is 'any' unless you specify one):

--- a/RPi4.md
+++ b/RPi4.md
@@ -183,15 +183,16 @@ ufw default deny incoming
 ufw default allow outgoing
 ```
 
-This command allows SSH connections from your LAN only.<br/>
-**⚠️ Replace `192.168.1.0` with your own subnet:**
+This command allows SSH connections from internal networks only:
 
 ```bash
-# local network
-ufw allow from 192.168.1.0/24 to any port 22
-
-# docker network, required for maintenance features
-ufw allow from 172.18.0.0/24 to any port 22
+ufw allow from 10.0.0.0/8 to any port 22 proto tcp
+ufw allow from 172.16.0.0/12 to any port 22 proto tcp
+ufw allow from 192.168.0.0/16 to any port 22 proto tcp
+ufw allow from 169.254.0.0/16 to any port 22 proto tcp
+ufw allow from fc00::/7 to any port 22 proto tcp
+ufw allow from fe80::/10 to any port 22 proto tcp
+ufw allow from ff00::/8 to any port 22 proto tcp
 ```
 
 These ports need to be accessible from anywhere (The default subnet is 'any' unless you specify one):


### PR DESCRIPTION
Otherwise the [maintenance features](https://docs.btcpayserver.org/faq-and-common-issues/faq-serversettings#maintenance-1) do not work, as the firewall blocks SSH connections from the Docker container.