### PR TITLE
Update FastSync FAQ

### DIFF
--- a/FAQ/FAQ-Synchronization.md
+++ b/FAQ/FAQ-Synchronization.md
@@ -31,6 +31,8 @@ btcpay-up.sh
 ```
 After FastSync is complete and you have brought back up your instance, refresh your BTCPay domain and wait for remaining blockchain synchronization. You can also follow [this video](https://youtu.be/VNMnd-dX9Q8?t=1730).
 
+If your FastSync returns: `You need to delete your Bitcoin Core wallet` after you load the uxto set, it means you need to delete your internal Bitcoin Core wallet that is not compatible with your newly pruned node. WARNING: Do not delete this wallet if you have any funds on it. (For example, this may be the case if you use Eclair or FullyNoded to receive funds). If you agree to remove the wallet to finish syncing with FastSync, use `docker volume rm generated_bitcoin_wallet_datadir` before you run `btcpay-up.sh`
+
 ## How do I know that BTCPay synced completely?
 
 When you do not see a pop-up message in the bottom right corner, which shows the sync progress, that means that your server is fully synced and you can [begin using it](/RegisterAccount.md).

--- a/FAQ/FAQ-Synchronization.md
+++ b/FAQ/FAQ-Synchronization.md
@@ -31,7 +31,7 @@ btcpay-up.sh
 ```
 After FastSync is complete and you have brought back up your instance, refresh your BTCPay domain and wait for remaining blockchain synchronization. You can also follow [this video](https://youtu.be/VNMnd-dX9Q8?t=1730).
 
-If your FastSync returns: `You need to delete your Bitcoin Core wallet` after you load the uxto set, it means you need to delete your internal Bitcoin Core wallet that is not compatible with your newly pruned node. WARNING: Do not delete this wallet if you have any funds on it. (For example, this may be the case if you use Eclair or FullyNoded to receive funds). If you agree to remove the wallet to finish syncing with FastSync, use `docker volume rm generated_bitcoin_wallet_datadir` before you run `btcpay-up.sh`
+If your FastSync returns: `You need to delete your Bitcoin Core wallet` after you load the uxto set, or you find this error: `Last wallet synchronisation goes beyond pruned data` it means you need to delete your internal Bitcoin Core wallet that is not compatible with your newly pruned node. WARNING: Do not delete this wallet if you have any funds on it. (For example, this may be the case if you use Eclair or FullyNoded to receive funds). If you agree to remove the wallet to finish syncing with FastSync, use `docker volume rm generated_bitcoin_wallet_datadir` before you run `btcpay-up.sh`
 
 ## How do I know that BTCPay synced completely?
 

--- a/FAQ/FAQ-Synchronization.md
+++ b/FAQ/FAQ-Synchronization.md
@@ -31,7 +31,7 @@ btcpay-up.sh
 ```
 After FastSync is complete and you have brought back up your instance, refresh your BTCPay domain and wait for remaining blockchain synchronization. You can also follow [this video](https://youtu.be/VNMnd-dX9Q8?t=1730).
 
-If your FastSync returns: `You need to delete your Bitcoin Core wallet` after you load the uxto set, or you find this error: `Last wallet synchronisation goes beyond pruned data` it means you need to delete your internal Bitcoin Core wallet that is not compatible with your newly pruned node. WARNING: Do not delete this wallet if you have any funds on it. (For example, this may be the case if you use Eclair or FullyNoded to receive funds). If you agree to remove the wallet to finish syncing with FastSync, use `docker volume rm generated_bitcoin_wallet_datadir` before you run `btcpay-up.sh`
+If your FastSync returns: `You need to delete your Bitcoin Core wallet` after you load the uxto set, or you find this error: `Last wallet synchronisation goes beyond pruned data` it means that the bitcoin core wallet was created before FastSync and needs to be removed (likely because btcpayserver started without the utxoset at the first boot). WARNING: Do not delete this wallet if you have any funds on it. (For example, this may be the case if you use Eclair or FullyNoded to receive funds). If you agree to remove the wallet to finish syncing with FastSync, use `docker volume rm generated_bitcoin_wallet_datadir` before you run `btcpay-up.sh`
 
 ## How do I know that BTCPay synced completely?
 


### PR DESCRIPTION
#372 
Not sure if we need to mention the error: `Prune: last wallet synchronisation goes beyond pruned data.` 