### PR TITLE
RPI4: RAM filesystem for logs  command fix

### DIFF
--- a/RPi4.md
+++ b/RPi4.md
@@ -161,7 +161,7 @@ mount -a
 While you’re editing `/etc/fstab` add a RAM filesystem for logs (optional). This is also to prevent burning out your SD card too quickly.
 
 ```bash
-none        /var/log        tmpfs   size=10M,noatime         00
+echo 'none        /var/log        tmpfs   size=10M,noatime         00' >> /etc/fstab
 ```
 
 Mount the SSD partition and create a symlink for docker to use the SSD


### PR DESCRIPTION
make the RAM filesystem for logs command an actual command that you copy paste instead of leaving noobs to figure it out