### PR TITLE
Fix temperature command and firewall errors

### DIFF
--- a/RPi4.md
+++ b/RPi4.md
@@ -86,7 +86,7 @@ ssh 192.168.1.5 -l pi
 The default password for the “pi” user is “raspberry”. After SSH’ing in, the first thing I want to do is check the device’s CPU temperature to make sure the cooling system are working correctly. Press Ctrl-c to stop monitoring:
 
 ```bash
-while :; do sudo su  -c "vcgencmd measure_temp"; sleep 1; done
+sudo watch -n1 vcgencmd measure_temp
 ```
 
 Next, let’s change the password for the “pi” user:

--- a/RPi4.md
+++ b/RPi4.md
@@ -83,10 +83,10 @@ The IP address that my Raspberry Pi got was 192.168.1.5 so I SSH’d to that:
 ssh 192.168.1.5 -l pi
 ```
 
-The default password for the “pi” user is “raspberry”. After SSH’ing in, the first thing I want to do is check the device’s CPU temperature to make sure the cooling system are working correctly:
+The default password for the “pi” user is “raspberry”. After SSH’ing in, the first thing I want to do is check the device’s CPU temperature to make sure the cooling system are working correctly. Press Ctrl-c to stop monitoring:
 
 ```bash
-sudo -svcgencmd measure_temp
+while :; do sudo su  -c "vcgencmd measure_temp"; sleep 1; done
 ```
 
 Next, let’s change the password for the “pi” user:
@@ -170,6 +170,12 @@ Install a firewall and allow SSH, HTTP, HTTPS, Bitcoin, and Lightning:
 apt install -y ufw
 ufw default deny incoming
 ufw default allow outgoing
+```
+
+UFW needs default iptables changes and a reboot for the firewall to work:
+```bash
+sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
+sudo reboot
 ```
 
 This command allows SSH connections from internal networks only:


### PR DESCRIPTION
- the old temperature command (`sudo -svcgencmd measure_temp`) does not work on Rasbian 10 (Buster) 
-  add a while loop to take multiple measurements every 1 second
- fix `ufw` firewall, the old command on  Rasbian 10 (Buster)  would produce "ERROR: Couldn't determine iptables version" (see https://raspberrypi.stackexchange.com/questions/100598/ufw-and-iptables-on-buster )