### PR TITLE
Updating docs to be explicit about pruning with FastSync

### DIFF
--- a/RPi3.md
+++ b/RPi3.md
@@ -231,7 +231,7 @@ export BTCPAYGEN_ADDITIONAL_FRAGMENTS="opt-save-storage-xs;opt-save-memory"
 export BTCPAY_ENABLE_SSH=true
 ```
 
-Adding the `opt-save-storage-xs` fragment will keep around 3 months of blocks (prune BTC for 25 GB), and is necessary for FastSync to work. See other pruning levels [here](https://github.com/btcpayserver/btcpayserver-docker#generated-docker-compose-). 
+Adding the `opt-save-storage-xs` fragment will tell Bitcoin Core to keep around 3 months of blocks, or 25 GB of disk space. See other pruning levels [here](https://github.com/btcpayserver/btcpayserver-docker#generated-docker-compose-). Pruning is necessary for FastSync to work.
 
 If you want to use multiple hostnames, add them via the optional `BTCPAY_ADDITIONAL_HOSTS` variable:
 ```bash

--- a/RPi3.md
+++ b/RPi3.md
@@ -231,6 +231,8 @@ export BTCPAYGEN_ADDITIONAL_FRAGMENTS="opt-save-storage-xs;opt-save-memory"
 export BTCPAY_ENABLE_SSH=true
 ```
 
+Adding the `opt-save-storage-xs` fragment will keep around 3 months of blocks (prune BTC for 25 GB), and is necessary for FastSync to work. See other pruning levels [here](https://github.com/btcpayserver/btcpayserver-docker#generated-docker-compose-). 
+
 If you want to use multiple hostnames, add them via the optional `BTCPAY_ADDITIONAL_HOSTS` variable:
 ```bash
 export BTCPAY_ADDITIONAL_HOSTS="raspberrypi.local,btcpay.local"


### PR DESCRIPTION
Using the pi 4 guide, I was setting up my raspberry pi 4 with FastSync and didn't realize I was missing something from the pi 3 guide about how to enable pruning on my node.

This fork adds a comment to the pi 3 guide about why a certain fragment is necessary for FastSync and has a link to more pruning options.