### PR TITLE
Update bitcoin core version

### DIFF
--- a/ManualDeployment.md
+++ b/ManualDeployment.md
@@ -21,7 +21,7 @@ The docker deployment will provide you easy update system and make sure that all
 
 ## Typical manual installation
 
-This steps have been done on Ubuntu 16.04, adapt for your own install.
+This steps have been done on Ubuntu 18.04, adapt for your own install.
 
 
 ### 1) Install Bitcoin Core 0.19.1

--- a/ManualDeployment.md
+++ b/ManualDeployment.md
@@ -24,12 +24,12 @@ The docker deployment will provide you easy update system and make sure that all
 This steps have been done on Ubuntu 16.04, adapt for your own install.
 
 
-### 1) Install Bitcoin Core 0.17.0
+### 1) Install Bitcoin Core 0.19.1
 
 ```bash
-BITCOIN_VERSION="0.17.0"
-BITCOIN_URL="https://bitcoincore.org/bin/bitcoin-core-0.17.0/bitcoin-0.17.0-x86_64-linux-gnu.tar.gz"
-BITCOIN_SHA256="9d6b472dc2aceedb1a974b93a3003a81b7e0265963bd2aa0acdcb17598215a4f"
+BITCOIN_VERSION="0.19.1"
+BITCOIN_URL="https://bitcoin.org/bin/bitcoin-core-0.19.1/bitcoin-0.19.1-x86_64-linux-gnu.tar.gz"
+BITCOIN_SHA256="5fcac9416e486d4960e1a946145566350ca670f9aaba99de6542080851122e4c"
 
 # install bitcoin binaries
 cd /tmp

--- a/ManualDeployment.md
+++ b/ManualDeployment.md
@@ -41,10 +41,10 @@ rm bitcoin.tar.gz
 ```
 
 ### 2) Install .NET Core SDK 3.1
-On my ubuntu 16.04 (See [these instructions](https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1604) or [here](https://dotnet.microsoft.com/download) for different OS).
+On my ubuntu 18.04 (See [these instructions](https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1804) or [here](https://dotnet.microsoft.com/download) for different OS).
 
 ```bash
-wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
+wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 sudo apt-get install apt-transport-https
 sudo apt-get update

--- a/ManualDeploymentExtended.md
+++ b/ManualDeploymentExtended.md
@@ -350,8 +350,8 @@ The gateway to the Bitcoin network for BTCPay Server components.
 
 ##### 1. Download the latest binaries from a trusted source such as [https://bitcoincore.org/en/download/](https://bitcoincore.org/en/download/).
 ```bash
-~$ wget https://bitcoincore.org/bin/bitcoin-core-0.18.0/bitcoin-0.18.0-x86_64-linux-gnu.tar.gz
-~$ wget https://bitcoincore.org/bin/bitcoin-core-0.18.0/SHA256SUMS.asc
+~$ wget https://bitcoincore.org/bin/bitcoin-core-0.19.1/bitcoin-0.19.1-x86_64-linux-gnu.tar.gz
+~$ wget https://bitcoincore.org/bin/bitcoin-core-0.19.1/SHA256SUMS.asc
 ```
 ##### 2. Verify the authenticity of the downloads.
 The Bitcoin Core code signing key is currently:
@@ -366,15 +366,15 @@ It's advisable to double check the signing key corresponds with other available 
 ~$ gpg --verify SHA256SUMS.asc
  gpg: Good signature from "Wladimir J. van der Laan (Bitcoin Core binary release signing key) <laanwj@gmail.com>" [unknown]
 ~$ sha256sum --ignore-missing -c SHA256SUMS.asc
- bitcoin-0.18.0-x86_64-linux-gnu.tar.gz: OK
+ bitcoin-0.19.1-x86_64-linux-gnu.tar.gz: OK
 ```
 ##### 3. Install the binaries.
 
 ```bash
-~$ tar zxf bitcoin-0.18.0-x86_64-linux-gnu.tar.gz
-~$ pushd bitcoin-0.18.0/bin; sudo cp bitcoind bitcoin-cli /usr/bin; popd;
+~$ tar zxf bitcoin-0.19.1-x86_64-linux-gnu.tar.gz
+~$ pushd bitcoin-0.19.1/bin; sudo cp bitcoind bitcoin-cli /usr/bin; popd;
 ~$ bitcoind --version
-Bitcoin Core Daemon version v0.18.0
+Bitcoin Core version v0.19.1
 ```
 ##### 4. Create the configuration file.
 An example configuration file is available on the Bitcoin Core repository at https://github.com/bitcoin/bitcoin/blob/master/share/examples/bitcoin.conf.


### PR DESCRIPTION
- Update bitcoin core version to 19.1
- Verify sig from https://bitcoincore.org/bin/bitcoin-core-0.19.1/SHA256SUMS.asc
- Update Ubuntu version
- Update .net core download link for Ubuntu 18.04