### PR TITLE
Fix video integration

### DIFF
--- a/docs/.vuepress/preprocessMarkdown.js
+++ b/docs/.vuepress/preprocessMarkdown.js
@@ -1,6 +1,6 @@
 // replace youtube links with embed
 module.exports = source =>
-  source.replace(/\[(!.*)\]\((.*youtube\.com.*?)(?:\s"(.*?)")?\)/i, (all, preview, url, text) => {
+  source.replace(/\[(!.*)\]\((.*youtube\.com.*?)(?:\s"(.*?)")?\)/gi, (all, preview, url, text) => {
     const [, query] = url.match(/\?(.*)/)
     const params = query.split('&').reduce((res, param) => {
       const [key, val] = param.split('=')


### PR DESCRIPTION
The regular expression was missing the global flag, so that only the first video preview got replaced. Closes #525.