### PR TITLE
Add Features Overview video to readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@ Please check out our [official website](https://btcpayserver.org/), our [complet
 * Internal, full-node reliant wallet with [hardware wallet integration](Vault.md)
 * [Payjoin Support](Payjoin.md)
 
+[![How BTCPay Server Features Overview](https://img.youtube.com/vi/R-yaXk4NvEs/mqdefault.jpg)](https://www.youtube.com/watch?v=R-yaXk4NvEs)
+
 ## How it works
 
 [![How BTCPay Works](./img/thumbnails/HowBTCPayServerWorks.png)](https://www.youtube.com/watch?v=nr0UNbz3AoQ "How BTCPay Server Works")


### PR DESCRIPTION
- Adds Brit's video that covers features, under the features section.

Don't get confused by the video preview being smaller on GitHub. On VuePress front-end looks good. As the matter a fact, I think this shows we can from now on use 
`https://img.youtube.com/vi/VIDEOURL/mqdefault.jpg` to embed videos and save space for thumbnail upload. Related to #519 


![preview](https://user-images.githubusercontent.com/36959754/82195113-277c7280-98f8-11ea-81cc-5062e9b77087.PNG)
