### PR TITLE
Fix video integration for older iOS

### DIFF
--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -22,6 +22,7 @@ const handleClick = e => {
 
   // youtube previews
   if (e.target.matches('.ytEmbed')) {
+    e.preventDefault()
     openVideo(e.target)
   }
 }

--- a/docs/.vuepress/preprocessMarkdown.js
+++ b/docs/.vuepress/preprocessMarkdown.js
@@ -28,7 +28,7 @@ const replaceYouTubeLinks = source =>
     const path = t ? `${v}?start=${t}` : `${v}?`
 
     return `
-<div class="ytEmbed" data-id="${v}" style="background-image:url(https://img.youtube.com/vi/${v}/hqdefault.jpg);">
+<a href="${url}" class="ytEmbed" data-id="${v}" style="background-image:url(https://img.youtube.com/vi/${v}/hqdefault.jpg);">
   <iframe
     title="YouTube: ${text || v}"
     data-src="https://www.youtube-nocookie.com/embed/${path}&autoplay=1&autohide=1&modestbranding=1&color=white&rel=0"
@@ -36,7 +36,7 @@ const replaceYouTubeLinks = source =>
     allow="autoplay;encrypted-media;picture-in-picture"
     allowfullscreen
   ></iframe>
-</div>`
+</a>`
   })
 
 module.exports = source => {

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -457,6 +457,7 @@ body {
   }
 
   .ytEmbed {
+    display: block;
     position: relative;
     margin: 1rem 0 2rem;
     height: 0;


### PR DESCRIPTION
@britttttk mentioned on the chat, that she isn't able to play the videos on an iOS 7 device. Could reproduce it with an older iPad. Here's the fix and also a proper fallback for disabled JavaScript.