### PR TITLE
Add redirect for old link

### DIFF
--- a/docs/.vuepress/redirects.js
+++ b/docs/.vuepress/redirects.js
@@ -5,6 +5,7 @@ module.exports = [
   { path: '/btcpay-basics/walkthrough', redirect: '/Walkthrough/' },
   { path: '/btcpay-basics/btcpayvsothers', redirect: '/BTCPayVsOthers/' },
   { path: '/btcpay-basics/tryitout', redirect: '/TryItOut/' },
+  { path: '/btcpay-basics/gettingstarted', redirect: '/RegisterAccount/' },
   // Deployment
   { path: '/deployment', redirect: '/Deployment/' },
   { path: '/deployment/deployment', redirect: '/Deployment/' },


### PR DESCRIPTION
Addresses btcpayserver/btcpayserver.org#121, but should be properly fixed with updating the link in the website footer. Nevertheless let's add this redirect as the URL seems to be out there :)