### PR TITLE
Add Greenfield API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 # External repos
 /docs/Transmuter
 /docs/Docker
+/docs/.vuepress/public/API/Greenfield/**/*.json

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -278,7 +278,8 @@ module.exports = {
           ["/Architecture", "Architecture"],
           ["/LocalDevelopment", "Developing Locally"],
           ["/Altcoins", "How to add an Altcoin"],
-          ["/Theme", "Customizing Themes"]
+          ["/Theme", "Customizing Themes"],
+          ["https://docs.btcpayserver.org/API/Greenfield/v1", "Greenfield API v1", { type: 'external' }]
         ]
       }
     ]

--- a/docs/.vuepress/public/API/Greenfield/v1/index.html
+++ b/docs/.vuepress/public/API/Greenfield/v1/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>BTCPay Greenfield API (v1)</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+        }
+    </style>
+</head>
+<body>
+    <redoc spec-url="./swagger.json"></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.24/bundles/redoc.standalone.js" integrity="sha384-ZO+OTQZMsYIcoraCBa8iJW/5b2O8K1ujHmRfOwSvpVBlHUeKq5t3/kh1p8JQJ99X" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/setup-deps.sh
+++ b/setup-deps.sh
@@ -5,6 +5,7 @@ set -e
 BASE_DIR=$(cd `dirname $0` && pwd)
 DOCS_DIR=$BASE_DIR/docs
 PUBLIC_DIR=$DOCS_DIR/.vuepress/public
+BTCPAYSERVER_DIR=$BASE_DIR/deps/btcpayserver
 DOCKER_DIR=$BASE_DIR/deps/docker
 TRANSMUTER_DIR=$BASE_DIR/deps/transmuter
 
@@ -15,6 +16,20 @@ editLink: false\
 ---\
 *' $1
 }
+
+# BTCPay Server
+
+rm -rf $DOCS_DIR/BTCPayServer
+mkdir -p $DOCS_DIR/BTCPayServer
+
+if [ ! -d $BTCPAYSERVER_DIR ]; then
+  git clone https://github.com/btcpayserver/btcpayserver.git $BTCPAYSERVER_DIR
+else
+  cd $BTCPAYSERVER_DIR && git checkout master && git pull
+fi
+
+cd $BTCPAYSERVER_DIR
+jq -rs 'reduce .[] as $item ({}; . * $item)' BTCPayServer/wwwroot/swagger/v1/*.json > $PUBLIC_DIR/API/Greenfield/v1/swagger.json
 
 # Docker
 


### PR DESCRIPTION
Pretty straight forward: Checks out the BTCPay Server repo and combines the individual swagger JSON files into one. Copies this to a directory we make available separately from the rest of the docs, as this uses the ReDoc layout.

The link in the sidebar has to be an absolute URL as I haven't found a way to link to an "internal" page as an external resource … so keep in mind you have to manually visit [http://localhost:8080/API/Greenfield/v1/](http://localhost:8080/API/Greenfield/v1/) to see the result.
And you need to run `./setup-deps.sh` after checking out this branch, as the BTCPayServer repo is a new dependency.

Closes btcpayserver/btcpayserver#1613.

### TODOs after merge:

- [ ] Add [external doc update trigger](https://github.com/btcpayserver/btcpayserver-doc#external-documentation-repos) for BTCPayServer master build.