### PR TITLE
Reorder build steps

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,16 +23,18 @@ jobs:
       # Checkout doc repo and its dependencies
       - name: Checkout
         uses: actions/checkout@v2
-      # Setup Node and link the dependencies
+      # Setup Node
       - name: Setup (Node.js ${{ matrix.node-version }})
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Setup dependencies
-        run: ./setup-deps.sh
       # Install, test and build
       - name: Install
         run: npm ci
+      # Link the dependencies
+      - name: Setup dependencies
+        run: ./setup-deps.sh
+      # Test and build
       - name: Test
         run: npm test
       - name: Build

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ In order to build the website locally, you'll need [Node.js](https://nodejs.org/
 The setup is straight forward:
 
 ```bash
-# Link external doc repos
-./setup-deps.sh
-
 # Install dependencies
 npm install
+
+# Link external doc repos
+./setup-deps.sh
 
 # Serve locally (by default on port 8080)
 npm start


### PR DESCRIPTION
My recent PR #580 broke the build as the `setup-deps.sh` script now needs to run after the node dependencies are installed.