### PR TITLE
Command to check tor needs to be sudoed

### DIFF
--- a/docs/ManualDeploymentExtended.md
+++ b/docs/ManualDeploymentExtended.md
@@ -149,7 +149,7 @@ Covered further in Bitcoin and Lightning Network Daemon sections.
 ##### 👍 Check
 
 ```bash
-~$ netstat -tlnp | grep tor # (lines below correspond to the tor control port and SOCKS proxy)
+~$ sudo netstat -tlnp | grep tor # (lines below correspond to the tor control port and SOCKS proxy)
 tcp        0      0 127.0.0.1:9050          0.0.0.0:*               LISTEN      1376/tor
 tcp        0      0 127.0.0.1:9051          0.0.0.0:*               LISTEN      1376/tor
 ```


### PR DESCRIPTION
Ran the command on Ubuntu server 20 running on a raspberry pi 4 and got the following:

```
$ netstat -tlnp | grep tor
(Not all processes could be identified, non-owned process info
 will not be shown, you would have to be root to see it all.)
```