### PR TITLE
Updated extended manual deployment instructions for Ubuntu 20.04

### DIFF
--- a/docs/ManualDeploymentExtended.md
+++ b/docs/ManualDeploymentExtended.md
@@ -360,7 +360,7 @@ nginx version: nginx/1.18.0 (Ubuntu)
 ```
 
 ```bash
-~$ sudo sudo netstat -tlnp | grep nginx
+~$ sudo netstat -tlnp | grep nginx
 tcp        0      0 0.0.0.0:443             0.0.0.0:*               LISTEN      266275/nginx: maste
 tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      266275/nginx: maste
 tcp6       0      0 :::443                  :::*                    LISTEN      266275/nginx: maste


### PR DESCRIPTION
Updated extended manual deployment instructions for Ubuntu 20.04 and latest versions of application components (btc, lnd and rtl).

Adjusted steps where necessary for changes to deployment instructions for each application.

Changed the Bitcoin Core instructions to build from source rather than download. WIth this change the instructions now document a full build from source solution for BTCPay Server.