### PR TITLE
Add documentation on development environment setup

### DIFF
--- a/docs/LocalDevelopment.md
+++ b/docs/LocalDevelopment.md
@@ -76,7 +76,7 @@ cd BTCPayServer.Tests
 dotnet test
 ```
 
-The concept of `launch profile` does not apply for tests, but the concept build configuration do, for example if I want to run tests on the Release build:
+The concept of `launch profile` does not apply for tests, but the concept of build configuration does. For example, if I want to run tests on the Release build:
 
 ```bash
 dotnet test -c Release

--- a/docs/LocalDevelopment.md
+++ b/docs/LocalDevelopment.md
@@ -30,7 +30,7 @@ This will run a BTCPayServer instance connecting to the services in your Docker 
 
 ## Build configuration
 
-A build configuration defines how to build BTCPay Server. For example, Whether to include some source files, whether to optimize for debugging or performance.
+A build configuration defines how to build BTCPay Server. For example, whether to include some source files, whether to optimize for debugging or performance.
 
 There are several build configurations:
 * `Debug`

--- a/docs/LocalDevelopment.md
+++ b/docs/LocalDevelopment.md
@@ -92,7 +92,7 @@ If you use an IDE, consult your IDE documentation to run tests or switch to diff
 
 By default, your IDE or simple `dotnet run` will use `Bitcoin` launch profile on `Debug` build.
 
-* This mean that BTCPay Server will be hosted on a local HTTP port, building without altcoin support,
+* This means that BTCPay Server will be hosted on a local HTTP port, building without altcoin support,
 * Run BTCPay Server to connect to Bitcoin only dependencies specified in [BTCPayServer.Tests/docker-compose.yml](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer.Tests/docker-compose.yml).
 
 If you want to develop with altcoins support you need to use the `Altcoins-HTTPS` launch profile, on the `Altcoins-Debug` build, and run the [BTCPayServer.Tests/docker-compose.altcoins.yml](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer.Tests/docker-compose.altcoins.yml).

--- a/docs/LocalDevelopment.md
+++ b/docs/LocalDevelopment.md
@@ -54,7 +54,7 @@ Those parameters are wrapped into what the dotnet concept of `launch profile`.
 
 The launch profiles are specified in the [launchSettings.json](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer/Properties/launchSettings.json).
 
-There is currently three launch profiles: 
+There are currently three launch profiles: 
 * `Bitcoin`
 * `Bitcoin-HTTPS`
 * `Altcoins-HTTPS`

--- a/docs/LocalDevelopment.md
+++ b/docs/LocalDevelopment.md
@@ -115,7 +115,7 @@ dotnet test -c Altcoins-Debug
 
 ## HTTPS support for local development
 
-Some browser security features may requires that you use HTTPS to be properly tested.
+Some browser security features may require that you use HTTPS to be properly tested.
 
 In this case, use `Bitcoin-HTTPS` (or `Altcoin-HTTPS`) launch profile. This will create a self signed certificate for your development purpose.
 
@@ -128,7 +128,7 @@ dotnet dev-certs https --trust
 
 ## Test utilities
 
-There is some useful scripts that you can use during development time to simulate payments.
+There are some useful scripts that you can use during development time to simulate payments.
 
 Please, see [README of the test project](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer.Tests/README.md).
 

--- a/docs/LocalDevelopment.md
+++ b/docs/LocalDevelopment.md
@@ -9,13 +9,9 @@ For the development environment you need to install these tools:
 
 ## Dependencies
 
-To execute tests and run the project for debugging you also need instances of the following running and configured on the right ports:
+To execute tests and run the project for debugging, you need to run a number of dependencies.
 
-* [NBXplorer](https://github.com/dgarage/NBxplorer)
-* [Postgres](https://www.postgresql.org/)
-* [Bitcoin Core](https://bitcoincore.org/) (and optionally other full nodes)
-
-We recommend you use our dockerized setup to bootstrap the development environment:
+We wrapped all our dependencies in a docker-compose file that you can use to bootstrap the development environment:
 The file [BTCPayServer.Tests/docker-compose.yml](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer.Tests/docker-compose.yml) can be used to spin everything up:
 
 ```bash
@@ -24,15 +20,119 @@ cd btcpayserver/BTCPayServer.Tests
 docker-compose up dev
 ```
 
-To get started see the [README of the test project](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer.Tests/README.md).
-
 ## Which IDE?
 
 We recommend using Visual Studio Code (cross platform) or Visual Studio 2019 (Windows Only) or Rider (cross platform).
 You can of course use VIM if you are hardcore, .NET Core is command-line environment friendly.
 
-Visual Studio Code, Visual Studio and Rider will run the debug profile Docker-Regtest.
+Visual Studio Code, Visual Studio and Rider will run the launch profile `Bitcoin`.
 This will run a BTCPayServer instance connecting to the services in your Docker service, so you can easily debug and step through the code.
+
+## Build configuration
+
+A build configuration defines how to build BTCPay Server. For example, Whether to include some source files, whether to optimize for debugging or performance.
+
+There are several build configurations:
+* `Debug`
+* `Release`
+* `Altcoins-Debug`
+* `Altcoins-Release`
+How to use a different one during your local development depends on your IDE.
+By default `Debug` is used, this is a Bitcoin only build excluding any altcoin dependencies. How to use a different one during your local development depends on your IDE.
+
+You can select which build to use via the `-c` switch in `dotnet` command line. If you use command line and want to run a Release build:
+
+```bash
+dotnet run -c Release
+```
+
+## Launch profiles
+
+When you start BTCPay Server locally for local development, it needs the right parameter so it can connect to the development time dependencies in the docker-compose file.
+
+Those parameters are wrapped into what the dotnet concept of `launch profile`.
+
+The launch profiles are specified in the [launchSettings.json](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer/Properties/launchSettings.json).
+
+There is currently three launch profiles: 
+* `Bitcoin`
+* `Bitcoin-HTTPS`
+* `Altcoins-HTTPS`
+
+By default, `Bitcoin` is used. How to use a different one during your local development depends on your IDE.
+
+If you use command line, `dotnet run` allows you to select the launch profile of your choice:
+
+```
+dotnet run --launch-profile Bitcoin
+```
+
+## Running tests
+
+Running tests is functioning in the exact same way as running the development time BTCPay Server.
+
+```bash
+cd BTCPayServer.Tests
+dotnet test
+```
+
+The concept of `launch profile` does not apply for tests, but the concept build configuration do, for example if I want to run tests on the Release build:
+
+```bash
+dotnet test -c Release
+```
+
+The tests are already configured to use the development time dependencies in the docker-compose presented earlier.
+
+You can use the `--f` (filter) switch to run a specific test.
+
+If you use an IDE, consult your IDE documentation to run tests or switch to different configurations.
+
+## Altcoin support development
+
+By default, your IDE or simple `dotnet run` will use `Bitcoin` launch profile on `Debug` build.
+
+* This mean that BTCPay Server will be hosted on a local HTTP port, building without altcoin support,
+* Run BTCPay Server to connect to Bitcoin only dependencies specified in [BTCPayServer.Tests/docker-compose.yml](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer.Tests/docker-compose.yml).
+
+If you want to develop with altcoins support you need to use the `Altcoins-HTTPS` launch profile, on the `Altcoins-Debug` build, and run the [BTCPayServer.Tests/docker-compose.altcoins.yml](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer.Tests/docker-compose.altcoins.yml).
+
+If using command line:
+
+```bash
+cd BTCPayServer.Tests
+docker-compose -f docker-compose.altcoins.yml up dev
+cd ../BTCPayServer
+dotnet run -c Altcoins-Debug --launch-profile Altcoins-HTTPS
+```
+
+For tests
+
+```bash
+cd BTCPayServer.Tests
+dotnet test -c Altcoins-Debug
+```
+
+## HTTPS support for local development
+
+Some browser security features may requires that you use HTTPS to be properly tested.
+
+In this case, use `Bitcoin-HTTPS` (or `Altcoin-HTTPS`) launch profile. This will create a self signed certificate for your development purpose.
+
+However, your browser will not trust it, making it difficult to debug.
+
+You can instruct your OS to trust this development time certificate by running:
+```bash
+dotnet dev-certs https --trust
+```
+
+## Test utilities
+
+There is some useful scripts that you can use during development time to simulate payments.
+
+Please, see [README of the test project](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer.Tests/README.md).
+
+## Configuration
 
 ## Videos
 

--- a/docs/LocalDevelopment.md
+++ b/docs/LocalDevelopment.md
@@ -50,7 +50,7 @@ dotnet run -c Release
 
 When you start BTCPay Server locally for local development, it needs the right parameter so it can connect to the development time dependencies in the docker-compose file.
 
-Those parameters are wrapped into what the dotnet concept of `launch profile`.
+Those parameters are wrapped into the dotnet concept of `launch profile`.
 
 The launch profiles are specified in the [launchSettings.json](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer/Properties/launchSettings.json).
 


### PR DESCRIPTION
With the recent refactor of isolating altcoins, development doc needed to be updated: ping @xpayserver