### PR TITLE
Hide single "ColdCard Wallet" item initially

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -260,6 +260,7 @@ module.exports = {
       {
         title: "Support and Community",
         collapsable: false,
+        initialOpenGroupIndex: -1,
         children: [
           {
             title: "FAQ and common issues",

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -189,6 +189,7 @@ module.exports = {
             title: "(3) Wallet Setup",
             path: "/WalletSetup",
             collapsable: false,
+            initialOpenGroupIndex: -1,
             children: [
               {
                 title: "Use existing hardware wallet",


### PR DESCRIPTION
Finally vuejs/vuepress#2408 got merged and is availabe as a release, so now we can hide the single "ColdCard Wallet" item initially. This is to prevent the assumption, that only ColdCard is supported.

Before:

![before](https://user-images.githubusercontent.com/886/89716483-9a543180-d9ad-11ea-94bb-48a5beb5dff9.png)

After:

![after](https://user-images.githubusercontent.com/886/89716477-945e5080-d9ad-11ea-9c87-912c780d4446.png)