### PR TITLE
Fix - Create README.md in ContributeWrite

### DIFF
--- a/docs/Contribute/ContributeWrite/README.md
+++ b/docs/Contribute/ContributeWrite/README.md
@@ -1,0 +1,32 @@
+# Why writing matters
+
+By giving essential and concise informations on software, or creating these documentation pages to help wrap your mind around the software stack, writers contributing to BTCPay Server are as important as any other contributor.
+
+If you have writing skills, if you have a fair knowledge of the English language, then you can contribute to BTCPay Server or review the work of other contributors.
+
+Writing contributors can help in a number of places like the [software](WriteSoftware.md), the [documentation](WriteDocs.md) or the [blog](WriteBlog.md) for example.
+
+
+**Important note**: Contributions explained in this documentation are meant to be done in **English** only. If you wish to contribute in other languages, see [Translations](../ContributeTranslate.md/)
+
+## Requirements and recommended software
+
+### Requirements
+
+In order to contribute to BTCPay Server as a writer there are some requirements.
+
+Since most of the writen done in BTCPay Server is done through Github, you must have a [Github account](https://github.com/).
+It's also on Github that you can review the work done by others.
+
+### Recommended software
+
+To be able to fork repositories, create and work on branches, make Pull Requets and Issues easily, in a word, Manage your contributions, it's recommended your have [Github Desktop](https://desktop.github.com/).
+
+It is also recommended to have a Rich-Text editor.
+
+[Notepad++](https://notepad-plus-plus.org/downloads/) is a decent software and easy to use for the newer contributors.
+
+For more advanced users, [Visual Studio Code (VS Code)](https://visualstudio.microsoft.com/) is a good choice.
+The `Markdown All In One` extension in VS Code is also recommended, for visual comfort while editing and the ability to preview Markdown changes.
+
+These are only recommended: If you already use other similar software that you're accustomed to, you are free to continue using them.


### PR DESCRIPTION
The README.md file in #689 didn't get created for some reason (folder doesn't contain README.md file on local, but contains the other ones created by preceding PR's), rendering a 404 on the production docs.
The github web version does contain the readme.md file though, so might be because of the capital MD in extension ?

This should fix it.