### PR TITLE
Add Invoice translation § to btcpayvsothers.md

### DIFF
--- a/docs/BTCPayVsOthers.md
+++ b/docs/BTCPayVsOthers.md
@@ -61,10 +61,15 @@ First rule of Bitcoin is always keep your private keys *private*. Using a secure
 Secondly, there is another area of security to consider on the applications layer where you have two main options:
 
 * **Option 1**: Most payment processors (including BTCPay Server) use the [BIP 21][1] standard.
+
 * **Option 2**: Others use variations of the [BIP 70][2] standard.
-     * **Note**: [BIP 70 has recently been deprecated in Bitcoin Core][3].
-     * Many wallets do not allow payments to BIP 70 invoice urls.
-     * Need help converting obsolete BIP 70 invoice urls to a BIP 21 invoice url? No problem, we can help with that too.<br>Here's our [BIP 70 invoice url converter][4].
+**Note**: [BIP 70 has recently been deprecated in Bitcoin Core][3].
+Some payment processors still use this depreciated standard, but some wallets will not be compatible. To be able to pay to a BIP 70 invoice, you need to translate it.
+In order to do so, every BTCPay Server instance also hosts a translation tool, that you can access by adding `/translate` to your BTCPay Server URL.
+
+Example: [mainnet.demo.btcpayserver.org/translate](https://mainnet.demo.btcpayserver.org/translate/)
+
+Simply input the invoice URL that you were given in the field to get it translated to a format most wallets will recognise.
 
 ----
 

--- a/docs/Invoices.md
+++ b/docs/Invoices.md
@@ -45,6 +45,7 @@ Table below lists and describes common invoice statuses in BTCPay and suggests c
 
 Some payment processors still use an deprecated standard to generate invoice.
 To translate such an invoice, every BTCPay Server instance also hosts a translation tool, that you can access by adding `/translate` to your BTCPay Server URL.
-Example: [https://mainnet.demo.btcpayserver.org/translate](mainnet.demo.btcpayserver.org/translate)
+
+Example: [mainnet.demo.btcpayserver.org/translate](https://mainnet.demo.btcpayserver.org/translate/)
 
 Simply input the invoice URL that you were given in the field to get it translated to a format most wallets will recognise.

--- a/docs/Invoices.md
+++ b/docs/Invoices.md
@@ -47,4 +47,4 @@ Some payment processors still use an deprecated standard to generate invoice.
 To translate such an invoice, every BTCPay Server instance also hosts a translation tool, that you can access by adding `/translate` to your BTCPay Server URL.
 Example: [https://mainnet.demo.btcpayserver.org/translate](mainnet.demo.btcpayserver.org/translate)
 
-Simply input the invoice URL that you where given in the field to get it translated to a format most wallets will recognise.
+Simply input the invoice URL that you were given in the field to get it translated to a format most wallets will recognise.

--- a/docs/Invoices.md
+++ b/docs/Invoices.md
@@ -40,3 +40,11 @@ Table below lists and describes common invoice statuses in BTCPay and suggests c
 * *Invoices paid via the [Lightning Network](./LightningNetwork.md) immediately go to a completed state, as their confirmation is instant.
 * **Paid Partial invoice usually happens when a buyer pays the invoice from the exchange wallet  which takes a fee for their service and deducts it from a total. In some cases, it happens when buyer enters an  incorrect amount in their wallet.
 * ***Invalid - If you're receiving a lot of invalid invoices in your store, you may want to [adjust invalid invoice time in store settings](./FAQ/FAQ-Stores.md#payment-invalid-if-transactions-fails-to-confirm-minutes-after-invoice-expiration).
+
+## Invoice translating
+
+Some payment processors still use an deprecated standard to generate invoice.
+To translate such an invoice, every BTCPay Server instance also hosts a translation tool, that you can access by adding `/translate` to your BTCPay Server URL.
+Example: [https://mainnet.demo.btcpayserver.org/translate](mainnet.demo.btcpayserver.org/translate)
+
+Simply input the invoice URL that you where given in the field to get it translated to a format most wallets will recognise.

--- a/docs/Invoices.md
+++ b/docs/Invoices.md
@@ -40,12 +40,3 @@ Table below lists and describes common invoice statuses in BTCPay and suggests c
 * *Invoices paid via the [Lightning Network](./LightningNetwork.md) immediately go to a completed state, as their confirmation is instant.
 * **Paid Partial invoice usually happens when a buyer pays the invoice from the exchange wallet  which takes a fee for their service and deducts it from a total. In some cases, it happens when buyer enters an  incorrect amount in their wallet.
 * ***Invalid - If you're receiving a lot of invalid invoices in your store, you may want to [adjust invalid invoice time in store settings](./FAQ/FAQ-Stores.md#payment-invalid-if-transactions-fails-to-confirm-minutes-after-invoice-expiration).
-
-## Invoice translating
-
-Some payment processors still use an deprecated standard to generate invoice.
-To translate such an invoice, every BTCPay Server instance also hosts a translation tool, that you can access by adding `/translate` to your BTCPay Server URL.
-
-Example: [mainnet.demo.btcpayserver.org/translate](https://mainnet.demo.btcpayserver.org/translate/)
-
-Simply input the invoice URL that you were given in the field to get it translated to a format most wallets will recognise.


### PR DESCRIPTION
Kukks mentioned in a recent tweet the invoice translator that is built in BTCPay Server.
It made me realize I couldn't recall if I saw mention of it in the docs, and searching in them resulted in nothing.

* Adds a § mentioning invoice translating in `invoice.md`

Unsure if I should add a screenshot. Doesn't seem absolutely necessary as usage is straightforward.