### PR TITLE
Add disable pruning to faq

### DIFF
--- a/docs/FAQ/FAQ-LightningNetwork.md
+++ b/docs/FAQ/FAQ-LightningNetwork.md
@@ -197,15 +197,6 @@ It is recommended to use c-lightning because the implementation supports pruned 
 It is possible in BTCPay to enable LND with a pruned node, however the LND implementation does not officially support it for reasons [listed here](https://github.com/lightningnetwork/lnd/blob/master/docs/safety.md#pruned-bitcoind-node). It's not possible to use pruning with Eclair.
 :::
 
-This will prune your Bitcoin full node to a maximum of 100GB (of blocks):
-
-```bash
-export BTCPAYGEN_ADDITIONAL_FRAGMENTS="opt-save-storage"`
-. ./btcpay-setup.sh -i
-```
-
-Other pruning options are [documented here](https://github.com/btcpayserver/btcpayserver-docker/blob/master/README.md#generated-docker-compose)
-
 ### Can I use my existing LN node with BTCPay?
 
 If you already have a well connected lightning node with sufficient inbound liquidity, you may want to use it with BTCPay instead of the included lightning node.

--- a/docs/FAQ/FAQ-Synchronization.md
+++ b/docs/FAQ/FAQ-Synchronization.md
@@ -8,7 +8,8 @@ This document covers the most common questions and issues that may occur during 
 * [BTCPay takes forever to synchronize](#btcpay-server-takes-forever-to-synchronize)
 * [BTCPay Server keeps showing that my node is always starting](#btcpay-server-keeps-showing-that-my-node-is-always-starting)
 * [I already have a synced full node, can I use it with BTCPay?](#im-running-a-full-node-and-have-a-synched-blockchain-can-btcpay-use-it-so-that-it-doesnt-have-to-do-a-full-sync)
-* [How to disable Bitcoin node pruning?](#how-to-enable-bitcoin-node-pruning)
+* [How to enable Bitcoin node pruning?](#how-to-enable-bitcoin-node-pruning)
+* [How to disable Bitcoin node pruning?](#how-to-disable-bitcoin-node-pruning)
 
 ## Why does BTCPay sync?
 
@@ -222,19 +223,30 @@ Your BTCPay Server should now be fully synched.
 
 If after this BTCPay Server keeps showing that your node is always starting, see the cause of [BTCPay Server keeps showing that my node is always starting](#btcpay-server-keeps-showing-that-my-node-is-always-starting).
 
+## How to enable Bitcoin node pruning?
+
+This will prune your Bitcoin full node to a maximum of 100GB (of blocks):
+
+```bash
+export BTCPAYGEN_ADDITIONAL_FRAGMENTS="opt-save-storage"
+. ./btcpay-setup.sh -i
+```
+
+Other pruning options are [documented here](https://github.com/btcpayserver/btcpayserver-docker/blob/master/README.md#generated-docker-compose)
+
 ## How to disable Bitcoin node pruning?
 
-To disable pruning of your Bitcoin node in BTCPay, first ensure you have enough memory to store the entire blockchain and BTCPayServer on your system. Then disable the opt-save-storage environment variable:
+To disable pruning of your Bitcoin node in BTCPay, first ensure you have enough memory to store the entire blockchain and BTCPayServer on your system. Then disable the `opt-save-storage` environment variable. See [this example](https://github.com/btcpayserver/btcpayserver-doc/blob/master/docs/FAQ/FAQ-Deployment.md#how-can-i-modify-or-deactivate-environment-variables) to view your fragment list and select only one for removal. The following example will remove **all** additional fragments: 
 
 ```bash
 sudo su -
 export BTCPAYGEN_ADDITIONAL_FRAGMENTS=""
-. btcpay-setup.sh -i
+. ./btcpay-setup.sh -i
 ```
 
-Then run the following commands to recreate the blockchain without pruning:
+Then run the following commands to recreate a non-pruned Bitcoin node:
 
-```
+```bash
 btcpay-down.sh
 # Delete 'blocks' and 'chainstate' folders
 rm -rf /var/lib/docker/volumes/generated_bitcoin_datadir/_data/blocks

--- a/docs/FAQ/FAQ-Synchronization.md
+++ b/docs/FAQ/FAQ-Synchronization.md
@@ -8,6 +8,7 @@ This document covers the most common questions and issues that may occur during 
 * [BTCPay takes forever to synchronize](#btcpay-server-takes-forever-to-synchronize)
 * [BTCPay Server keeps showing that my node is always starting](#btcpay-server-keeps-showing-that-my-node-is-always-starting)
 * [I already have a synced full node, can I use it with BTCPay?](#im-running-a-full-node-and-have-a-synched-blockchain-can-btcpay-use-it-so-that-it-doesnt-have-to-do-a-full-sync)
+* [How to disable Bitcoin node pruning?](#how-to-enable-bitcoin-node-pruning)
 
 ## Why does BTCPay sync?
 
@@ -220,3 +221,23 @@ To do that, follow the following steps :
 Your BTCPay Server should now be fully synched.
 
 If after this BTCPay Server keeps showing that your node is always starting, see the cause of [BTCPay Server keeps showing that my node is always starting](#btcpay-server-keeps-showing-that-my-node-is-always-starting).
+
+## How to disable Bitcoin node pruning?
+
+To disable pruning of your Bitcoin node in BTCPay, first ensure you have enough memory to store the entire blockchain and BTCPayServer on your system. Then disable the opt-save-storage environment variable:
+
+```bash
+sudo su -
+export BTCPAYGEN_ADDITIONAL_FRAGMENTS=""
+. btcpay-setup.sh -i
+```
+
+Then run the following commands to recreate the blockchain without pruning:
+
+```
+btcpay-down.sh
+# Delete 'blocks' and 'chainstate' folders
+rm -rf /var/lib/docker/volumes/generated_bitcoin_datadir/_data/blocks
+rm -rf /var/lib/docker/volumes/generated_bitcoin_datadir/_data/chainstate
+btcpay-up.sh
+```

--- a/docs/FAQ/FAQ-Synchronization.md
+++ b/docs/FAQ/FAQ-Synchronization.md
@@ -171,6 +171,23 @@ If you have recently tried to modify your environment variables using the `expor
 
 If you don't have enough memory to store the entire Bitcoin blockchain and you don't have an `opt-save-storage` listed when you [print the complete list of options](https://github.com/btcpayserver/btcpayserver-doc/blob/b0873a216f871b0f7dc4958c8fa63c17c35b603d/docs/FAQ/FAQ-Deployment.md#how-can-i-modify-or-deactivate-environment-variables) that you are running, it is very likely you have disabled pruning. 
 
+You can verify by checking your Bitcoind logs:
+
+```bash
+sudo su -
+cd btcpayserver-docker
+docker logs --tail 100 btcpayserver_bitcoind
+```
+
+If you see:
+
+```bash
+Block files have previously been pruned.
+You need to rebuild the database using -reindex to go back to unpruned mode.  
+This will redownload the entire blockchain. 
+Please restart with -reindex or -reindex-chainstate to recover.
+```
+
 You can simply [re-enable pruning](#how-to-enable-bitcoin-node-pruning) to solve the issue.
 
 ### Cause 4: Your bitcoin data directory is corrupted

--- a/docs/FAQ/README.md
+++ b/docs/FAQ/README.md
@@ -73,6 +73,7 @@ Common questions and issues that may occur during the initial sync of BTCPay.
 * [BTCPay takes forever to synchronize](./FAQ-Synchronization.md#btcpay-server-takes-forever-to-synchronize)
 * [BTCPay Server keeps showing that my node is always starting](./FAQ-Synchronization.md#btcpay-server-keeps-showing-that-my-node-is-always-starting)
 * [I already have a synced full node, can I use it with BTCPay?](./FAQ-Synchronization.md#im-running-a-full-node-and-have-a-synched-blockchain-can-btcpay-use-it-so-that-it-doesnt-have-to-do-a-full-sync)
+* [How to disable Bitcoin node pruning?](./FAQ-Synchronization.md#how-to-enable-bitcoin-node-pruning)
 
 ## [Integrations FAQ](./FAQ-Integrations.md)
 

--- a/docs/FAQ/README.md
+++ b/docs/FAQ/README.md
@@ -73,7 +73,8 @@ Common questions and issues that may occur during the initial sync of BTCPay.
 * [BTCPay takes forever to synchronize](./FAQ-Synchronization.md#btcpay-server-takes-forever-to-synchronize)
 * [BTCPay Server keeps showing that my node is always starting](./FAQ-Synchronization.md#btcpay-server-keeps-showing-that-my-node-is-always-starting)
 * [I already have a synced full node, can I use it with BTCPay?](./FAQ-Synchronization.md#im-running-a-full-node-and-have-a-synched-blockchain-can-btcpay-use-it-so-that-it-doesnt-have-to-do-a-full-sync)
-* [How to disable Bitcoin node pruning?](./FAQ-Synchronization.md#how-to-enable-bitcoin-node-pruning)
+* [How to enable Bitcoin node pruning?](./FAQ-Synchronization.md#how-to-enable-bitcoin-node-pruning)
+* [How to disable Bitcoin node pruning?](./FAQ-Synchronization.md#how-to-disable-bitcoin-node-pruning)
 
 ## [Integrations FAQ](./FAQ-Integrations.md)
 


### PR DESCRIPTION
closes #718
- add how to disable pruning to faq
- add how to enable pruning to faq (already in docker-repo faq but gives a more clear example in docs-repo for sync issue reference
- remove prune instructions from random places
- reorder sync issues based on how common they are in chats (afaik)
- add accidental removal of pruning to list of why node is syncing 