### PR TITLE
Fix latest tag lookup for btcpayserver repo

### DIFF
--- a/setup-deps.sh
+++ b/setup-deps.sh
@@ -40,7 +40,7 @@ for file in "$DOCS_DIR"/BTCPayServer/*.md; do
 done
 
 # Checkout latest release tag, so that we do not publish docs for unreleased APIs yet.
-git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
+git checkout $(git tag --sort=-refname | awk 'match($0, /^v[0-9]+\./)' | head -n 1)
 
 if command -v jq >/dev/null 2>&1; then
   jq -rs 'reduce .[] as $item ({}; . * $item)' BTCPayServer/wwwroot/swagger/v1/*.json > "$PUBLIC_DIR/API/Greenfield/v1/swagger.json"


### PR DESCRIPTION
Refines the lookup for the latest release tag for btcpayserver , so that only API docs for released versions get published.
The previous version incorporated all tags, assuming there are only release tags, which isn't the case.

This change ensures the tag name starts with `v[0-9].`