### PR TITLE
Add Light POS section under Point of Sale in apps.md

### DIFF
--- a/docs/Apps.md
+++ b/docs/Apps.md
@@ -25,7 +25,7 @@ To get your first Point of Sale app running, follow theses few simple steps:
 2. Add a `name` for your app
 3. Choose `app type` > Point Of Sale
 4. Select the `store` to associate with the app.
-5. Customize your PoS by choosing a `view` (static, Cart, Light), adding your own `items` with prices, photos, and a description.
+5. Customize your PoS by choosing a `view` (Static, Cart, Light), adding your own `items` with prices, photos, and a description.
 6. Click `Save Settings`.
 7. Click `View App` to view your PoS (Your customers can access the PoS through that link).
 

--- a/docs/Apps.md
+++ b/docs/Apps.md
@@ -14,13 +14,20 @@ Adding new products is easy. The app has a shopping cart feature, tips, product 
 
 Point of sale app can also be used for receiving donations or even as a small e-shop, depending on the customizations applied.
 
-1. Go to > Apps
-2. Add a name for your app
-3. Choose app type > Point Of Sale
-4. Select the store to associate with the app.
-5. Customize your PoS by adding your own items with prices, photos, and a description.
-6. Click "Save Settings".
-7. Click "View App" to view your PoS (Your customers can access the PoS through that link).
+Curently, the Point of Sale app supports three different views: 
+* A `Static` view representing only the items for sale.
+* A `Cart` view including items for sale and a cart for checkout.
+* A `Light` view consisting only of a keypad for easy and quick payments (Starting from [v1.0.5.6](https://blog.btcpayserver.org/btcpay-server-1-0-5-6/#simplePOS)).
+
+To get your first Point of Sale app running, follow theses few simple steps:
+
+1. Go to `Apps` and `Create a new app`
+2. Add a `name` for your app
+3. Choose `app type` > Point Of Sale
+4. Select the `store` to associate with the app.
+5. Customize your PoS by choosing a `view` (static, Cart, Light), adding your own `items` with prices, photos, and a description.
+6. Click `Save Settings`.
+7. Click `View App` to view your PoS (Your customers can access the PoS through that link).
 
 You can change the appearance of your Point of Sale app by following the [theme customization guide](./Theme.md).
 


### PR DESCRIPTION
Adds Light POS section under Point of Sale in apps.md

Closes #735

Specifically
* Adds a paragraphe mentionning the three possible views for a POS app
* Adds some `code` formatting for easier reading
* Adds a link to the blog post relating to the new Light POS feature.
Be advised, I updated said blog post to include a custom anchor to link directly to the relevant paragraphe `Simple Point Of Sale`.
Said link can be deleted in the future when we feel that most users will have updated to that version.