### PR TITLE
FAQ-Deployment - Broken links fix + Link cleanup

### DIFF
--- a/docs/FAQ/FAQ-Deployment.md
+++ b/docs/FAQ/FAQ-Deployment.md
@@ -6,41 +6,43 @@ This document covers the most common questions, errors, and issues you may encou
 
 Here are common questions about installation, regardless of the deployment method.
 
-* [How much does it cost to run BTCPay Server?](FAQ-Deployment.md#how-much-does-it-cost-to-run-btcpay-server)
-* [What are the minimal requirements for BTCPay?](FAQ-Deployment.md#what-are-the-minimal-requirements-for-btcpay)
-* [What is the easiest method to deploy a self-hosted BTCPay Server?](FAQ-Deployment.md#what-is-the-easiest-method-to-deploy-a-self-hosted-btcpay-server)
-* [How to choose a proper deployment method?](FAQ-Deployment.md#how-to-choose-a-proper-deployment-method)
-* [Why do I need a VPS? Can't I just run BTCPay on my home computer?](FAQ-Deployment.md#can-i-run-btcpay-on-my-home-computer)
-* [Can I run BTCPay on my hardware?](FAQ-Deployment.md#can-i-run-btcpay-on-my-own-hardware)
-* [Can I deploy on my existing VPS?](FAQ-Deployment.md#can-i-deploy-btcpay-on-my-existing-vps)
-* [Are there free hosts where I can test?](FAQ-Deployment.md#are-there-free-hosts-where-i-can-test)
-* [After initial deployment, I can't register and I don't have a login yet?](FAQ-Deployment.md#after-initial-deployment-i-can-t-register-and-i-don-t-have-a-login-yet)
-* [How do I activate Tor on my BTCPay Server?](FAQ-Deployment.md#how-do-i-activate-tor-on-my-btcpay-server)
-* [How do I disable Tor on my BTCPay Server?](FAQ-Deployment.md#how-do-i-disable-tor-on-my-btcpay-server)
-* [Why activate Tor? Does it mean that nobody knows who I am?](FAQ-Deployment.md#why-activate-tor-does-it-mean-that-nobody-knows-who-i-am)
-* [How to access the .onion address without clearnet?](FAQ-Deployment.md#how-to-access-the-onion-address-without-clearnet)
-* [How can I modify or deactivate environment variables?](FAQ-Deployment.md#how-can-i-modify-or-deactivate-environment-variables)
-* [How can I run BTCPay on testnet?](FAQ-Deployment.md#how-can-i-run-btcpay-on-testnet)
-* [Can I start BTCPay only when I'm expecting a payment?](FAQ-Deployment.md#can-i-start-btcpay-only-when-i-m-expecting-a-payment)
-* [Can I connect to my BTCPay Bitcoin P2P on port 8333?](FAQ-Deployment.md#can-i-connect-to-my-btcpay-bitcoin-p2p-on-port-8333)
+- [How much does it cost to run BTCPay Server?](#how-much-does-it-cost-to-run-btcpay-server)
+- [What are the minimal requirements for BTCPay?](#what-are-the-minimal-requirements-for-btcpay)
+- [What is the easiest method to deploy a self-hosted BTCPay Server?](#what-is-the-easiest-method-to-deploy-a-self-hosted-btcpay-server)
+- [How to choose a proper deployment method?](#how-to-choose-a-proper-deployment-method)
+- [Can I run BTCPay on my own hardware?](#can-i-run-btcpay-on-my-own-hardware)
+- [Can I deploy BTCPay on my existing VPS?](#can-i-deploy-btcpay-on-my-existing-vps)
+- [Are there free hosts where I can test?](#are-there-free-hosts-where-i-can-test)
+- [After initial deployment, I can't register and I don't have a login yet?](#after-initial-deployment-i-cant-register-and-i-dont-have-a-login-yet)
+- [How do I activate Tor on my BTCPay Server?](#how-do-i-activate-tor-on-my-btcpay-server)
+- [How do I disable Tor on my BTCPay Server?](#how-do-i-disable-tor-on-my-btcpay-server)
+- [Why activate Tor? Does it mean that nobody knows who I am?](#why-activate-tor-does-it-mean-that-nobody-knows-who-i-am)
+- [How to access the .onion address without clearnet?](#how-to-access-the-onion-address-without-clearnet)
+- [How can I modify or deactivate environment variables?](#how-can-i-modify-or-deactivate-environment-variables)
+- [How can I run BTCPay on testnet?](#how-can-i-run-btcpay-on-testnet)
+- [Can I start BTCPay only when I'm expecting a payment?](#can-i-start-btcpay-only-when-im-expecting-a-payment)
+- [Can I connect to my BTCPay Bitcoin P2P on port 8333?](#can-i-connect-to-my-btcpay-bitcoin-p2p-on-port-8333)
+- [Can I use an existing Nginx server as a reverse proxy with SSL termination?](#can-i-use-an-existing-nginx-server-as-a-reverse-proxy-with-ssl-termination)
+
 
 ## Web Deployment FAQ
 
 ### Luna Node Web Deployment FAQ
 
-* [How to change domain name on my LunaNode BTCPay?](FAQ-Deployment.md#how-to-change-domain-name-on-my-lunanode-btcpay)
+* [How to change domain name on my LunaNode BTCPay?](#how-to-change-domain-name-on-my-lunanode-btcpay)
 
 ## Manual Deployment FAQ
 
-* [How to manually install BTCPay on Ubuntu 18.04?](FAQ-Deployment.md#how-to-manually-install-btcpay-on-ubuntu-18-04)
-* [How do I completely uninstall BTCPay from a linux environment (docker version)](FAQ-Deployment.md#how-do-i-completely-uninstall-btcpay-from-a-linux-environment-docker-version)
-* [How to deploy BTCPay Server alongside existing Bitcoin full node?](./FAQ-Deployment.md#how-to-deploy-btcpay-server-alongside-existing-bitcoin-node)
-* [With the docker deployment, how to use a different volume for the data?](FAQ-Deployment.md#with-the-docker-deployment-how-to-use-a-different-volume-for-the-data)
-* [I get 503 Service Temporarily Unavailable nginx](FAQ-Deployment.md#i-get-503-service-temporarily-unavailable-nginx)
-  * [Cause 1: Trying to access my BTCPay by IP address](FAQ-Deployment.md#cause-1-trying-to-access-my-btcpay-by-ip-address)
-  * [Cause 2: btcpayserver or letsencrypt-nginx-proxy is not running](FAQ-Deployment.md#cause-2-btcpayserver-or-letsencrypt-nginx-proxy-is-not-running)
-  * [Cause 3: Error: BTCPay is expecting you to access this website from](FAQ-Deployment.md#cause-3-btcpay-is-expecting-you-to-access-this-website-from)
-  * [Cause 4: Getting 500 nginx error on a local server https and for http BTCPay is expecting you to access this website from](FAQ-Deployment.md#cause-4-getting-500-nginx-error-on-a-local-server-https-and-for-http-btcpay-is-expecting-you-to-access-this-website-from)
+* [How to manually install BTCPay on Ubuntu 18.04?](#how-to-manually-install-btcpay-on-ubuntu-1804)
+* [How do I completely uninstall BTCPay from a linux environment (docker version)](#how-do-i-completely-uninstall-btcpay-from-a-linux-environment-docker-version)
+* [How to deploy BTCPay Server alongside existing Bitcoin full node?](#how-to-deploy-btcpay-server-alongside-existing-bitcoin-node)
+* [With the docker deployment, how to use a different volume for the data?](#with-the-docker-deployment-how-to-use-a-different-volume-for-the-data)
+* [I get 503 Service Temporarily Unavailable nginx](#i-get-503-service-temporarily-unavailable-nginx)
+  * [Cause 1: Trying to access my BTCPay by IP address](#cause-1-trying-to-access-my-btcpay-by-ip-address)
+  * [Cause 2: btcpayserver or letsencrypt-nginx-proxy is not running](#cause-2-btcpayserver-or-letsencrypt-nginx-proxy-is-not-running)
+  * [Cause 3: Error: BTCPay is expecting you to access this website from](#cause-3-btcpay-is-expecting-you-to-access-this-website-from)
+  * [Cause 4: Getting 500 nginx error on a local server https and for http BTCPay is expecting you to access this website from](#cause-4-getting-500-nginx-error-on-a-local-server-https-and-for-http-btcpay-is-expecting-you-to-access-this-website-from)
+  * [Cause 5: Other](#cause-5-other)
 
 ## General Deployment
 
@@ -599,6 +601,6 @@ LimitRequestFieldSize 500000
 
 You need to open port 80 and 443. Once you did that, restart docker `btcpay-restart.sh`
 
-#### Cause N: Other
+#### Cause 5: Other
 
 There could be many causes for 5XX HTTP errors. Please create an [Issue](https://github.com/btcpayserver/btcpayserver-docker/issues) and when cause becomes known add it here in the [Deployment FAQ](FAQ-Deployment.md) doc.


### PR DESCRIPTION
A few of the relative links where broken in `FAQ-Deployment`.
Some of them because of typos (ie summary question not matching the text question) and for others because of `FAQ-Deployment.md` term in front, for some reason).

This PR fixes the `broken links` but also:
* Deletes `FAQ-Deployment` in the markdown summary relative links, cleaning them up for visibility
* Reorders summary questions to comply with the actual order of the questions in the text
* Renames `Cause N` to `Cause 5` and creates corresponding summary question/title & link