### PR TITLE
Manual deployment warnings

### DIFF
--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -6,7 +6,9 @@ Business deployment methods can vary by setup, maintenance, support, price, etc.
 
 BTCPay is a non-custodial invoicing system which eliminates the involvement of a third-party when managing funds. Payments with BTCPay go directly to your wallet. Your private keys are never uploaded to the server. Meaning 3rd Party BTCPay hosts do not control user funds, they are simply hosting your instance of the BTCPay software for you.
 
+:::danger
 Developer deployments are not recommended for production environments and require the user to have technical knowledge related to the build.
+:::
 
 ![Decision diagram](./img/DecisionDiagInstallBTCPayServer.png)
 
@@ -18,7 +20,7 @@ Developer deployments are not recommended for production environments and requir
 * [Google Cloud Deployment](./GoogleCloudDeployment.md) *
 * [Hardware Deployment](./HardwareDeployment.md) *
 * [Third-Party Hosting](./ThirdPartyHosting.md)
-* [Manual Deployment](./ManualDeployment.md)
+* [Manual Deployment](./ManualDeployment.md) **Not intended for production use**
 
 (*): Those deployments are using the Docker Deployment under the hood.
 

--- a/docs/ManualDeployment.md
+++ b/docs/ManualDeployment.md
@@ -1,5 +1,13 @@
 # Minimal manual setup
 
+:::danger
+#### Not recommended for production use
+
+Manual installation is NOT recommended for production use unless you are very confident with your Operating System and Bitcoin security expertise. If you are unsure use the docker deployment or one of the other [deployment options](./Deployment.md).
+
+#### You must have technical literacy and be able to resolve any issues on your own. The community will not provide extensive support for this deployment.
+:::
+
 The process is basically the following:
 
 1. Download and sync [Bitcoin Core](https://bitcoincore.org)

--- a/docs/ManualDeploymentExtended.md
+++ b/docs/ManualDeploymentExtended.md
@@ -8,6 +8,7 @@ The instructions also build all the application components from source which can
 #### Not recommended for production use
 
 Manual installation is NOT recommended for production use unless you are very confident with your Operating System and Bitcoin security expertise. If you are unsure use the docker deployment or one of the other [deployment options](./Deployment.md).
+#### You must have technical literacy and be able to resolve any issues on your own. The community will not provide extensive support for this deployment.
 :::
 
 ## Installation Steps Overview

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -130,7 +130,7 @@ Here's a good example of how to ask a question.
 > I'm having a problem with XYZ. I can replicate the problem. My BTCPay version is 0.100.31, and I deployed my server on Digital Ocean by following Docker deployment guide. I've searched through the FAQ and closed GitHub issues, but there's no solution to my problem. My BTCPay Setup is XYZ, and the issue is occurring when I do XYZ. Here are the logs I was able to get from my BTCPay instance. You can see the error in the image I attached.
 
 :::danger
-The community will only provide extensive support for production deployments. i.e. [Manual Deployments](ManualDeployment.md).
+The community will only provide extensive support for production deployments. i.e. [Manual Deployments](ManualDeployment.md) are not intended for production use.
 :::
 
 ### 4.1 Asking the community (general problems)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -129,6 +129,10 @@ Here's a good example of how to ask a question.
 
 > I'm having a problem with XYZ. I can replicate the problem. My BTCPay version is 0.100.31, and I deployed my server on Digital Ocean by following Docker deployment guide. I've searched through the FAQ and closed GitHub issues, but there's no solution to my problem. My BTCPay Setup is XYZ, and the issue is occurring when I do XYZ. Here are the logs I was able to get from my BTCPay instance. You can see the error in the image I attached.
 
+:::danger
+The community will only provide extensive support for production deployments. i.e. [Manual Deployments](ManualDeployment.md).
+:::
+
 ### 4.1 Asking the community (general problems)
 
 For quick answers to fundamental problems, it's best to post a question in #support channel on [BTCPay Mattermost](https://chat.btcpayserver.org/btcpayserver/channels/support).

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -130,7 +130,7 @@ Here's a good example of how to ask a question.
 > I'm having a problem with XYZ. I can replicate the problem. My BTCPay version is 0.100.31, and I deployed my server on Digital Ocean by following Docker deployment guide. I've searched through the FAQ and closed GitHub issues, but there's no solution to my problem. My BTCPay Setup is XYZ, and the issue is occurring when I do XYZ. Here are the logs I was able to get from my BTCPay instance. You can see the error in the image I attached.
 
 :::danger
-The community will only provide extensive support for production deployments. i.e. [Manual Deployments](ManualDeployment.md) are not intended for production use.
+The community will not provide extensive support for custom deployments. i.e. Variations of [Manual Deployments](ManualDeployment.md) are expected to be used only for development purposes and by users with technical literacy with the ability to **resolve deployment and maintenance issues on their own**. 
 :::
 
 ### 4.1 Asking the community (general problems)


### PR DESCRIPTION
Relates to #769 .
Adresses the initial issue, but not the suggestion in https://github.com/btcpayserver/btcpayserver-doc/issues/769#issuecomment-727656623 

* Convert an existing sentence into a warning in `Deployment.md`
* Add a short bold indication in the options bullet-points in `Deployment.md`
* Copy warning from `ExtendedManualDeployment.md` into `ManualDeployment.md`, just under the first H1
* Include an additional sentence to be explicit the community will not provide extensive support/support time for this deployment
* Add this additional sentence to already existing warning in `ManualDeploymentExtended.md`
* Add warning in `Troubleshooting.md` in the "Ask for help" section.