### PR TITLE
Search improvements

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -64,7 +64,8 @@ module.exports = {
       apiKey: '6a3a4c4380385cb5c9f9070247fdfca6',
       // See https://www.algolia.com/doc/api-reference/api-parameters/
       algoliaOptions: {
-        hitsPerPage: 10
+        // hitsPerPage: 10,
+        typoTolerance: 'min'
       },
       // See https://community.algolia.com/docsearch/behavior.html#autocompleteoptions
       autocompleteOptions: {

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -43,7 +43,7 @@ h5, h6 {
 }
 
 :root[data-btcpay-theme="dark"] #app .navbar .search-box input {
-  background-color: var(--btcpay-color-neutral-800) !important;
+  background-color: var(--btcpay-color-neutral-900) !important;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -257,24 +257,21 @@ h5, h6 {
   }
 
   .algolia-autocomplete .algolia-docsearch-suggestion--category-header {
-    border-color: var(--btcpay-border-color-light);
-  }
-
-  .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column {
     color: var(--btcpay-color-light-text) !important;
     background: var(--btcpay-color-light-backdrop) !important;
     border-color: var(--btcpay-border-color-medium);
+    padding: var(--btcpay-space-s) var(--btcpay-space-m) !important;
   }
 
-  .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column,
-  .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--content {
-    padding: var(--btcpay-space-xs) var(--btcpay-space-s) !important;
+  .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column {
+    display: none;
+  }
 
-    @media (max-width: 768px) {
+  .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--content {
       display: block !important;
       width: 100% !important;
       text-align: left !important;
-    }
+      padding: var(--btcpay-space-s) var(--btcpay-space-m) !important;
   }
 
   .algolia-docsearch-suggestion--subcategory-column-text:after {


### PR DESCRIPTION
Here we go with another stab at #628. 

### Summary

- Better results display (no more subcategory column)
- Decrease typo tolerance to have more focused results
- Remove `hitsPerPage` param, which filled up the results to at least ten

### Rationale

The last point reduces the search results to a maximum of five items, which is not exhaustive for terms like "wallet", as you can see in the examples below. However, I find this to bring more focus to the relevant results – the idea would be that people provide more context in case the initial five results aren't what they expected. But yeah, ideally there'd be a way to have a mix of Algolia returning all results that fit a term and not fill up results with unnecessary garbage, just because one demanded a certain count of results per page.

In general the index update (see algolia/docsearch-configs#2981) worked out good for us I think: Now the code samples are also included in the results. E.g. the search for `BTCPAYGEN_ADDITIONAL_FRAGMENTS` didn't yield much before, now one gets the relevant results from the code samples.

As you can also see in the examples below, the left subcategory column was mostly redundant – taking up space and making the information harder to grasp. It's now removed, which makes for an easier to cunsume results list.

# Examples – proposed vs. current

### wallet

![wallet-new](https://user-images.githubusercontent.com/886/101151853-90240600-3622-11eb-9314-c9da32f44b8a.png)

![wallet-old](https://user-images.githubusercontent.com/886/101151851-8ef2d900-3622-11eb-9b75-71ed74b72ac6.png)

### ssh

![ssh-new](https://user-images.githubusercontent.com/886/101151996-bcd81d80-3622-11eb-96eb-8e12c07a563c.png)

![ssh-old](https://user-images.githubusercontent.com/886/101152007-c19cd180-3622-11eb-93c4-f7fc4fa4fd11.png)

### transmuter 

![transmuter-new](https://user-images.githubusercontent.com/886/101151953-ad58d480-3622-11eb-8ead-091180d9d2f7.png)

![transmuter-old](https://user-images.githubusercontent.com/886/101151958-af229800-3622-11eb-8215-a8ad5fd560c4.png)
