### PR TITLE
Ypub-Zpub to Xpub conversion

### DIFF
--- a/docs/FAQ/FAQ-Apps.md
+++ b/docs/FAQ/FAQ-Apps.md
@@ -148,7 +148,7 @@ In your BTCPay Server, create two separate stores:
 1. Store for WooCommerce
 2. Store for Crowdfunding app
 
-Add the **same xpub derivation scheme**, so that both stores remain in sync.
+Add the **same extended public key derivation scheme**, so that both stores remain in sync.
 
 #### 2. Modifying CSS in WordPress
 

--- a/docs/FAQ/FAQ-Wallet.md
+++ b/docs/FAQ/FAQ-Wallet.md
@@ -91,7 +91,7 @@ Using different derivation schemes with your extended public key, you can also c
 |Multi-sig P2SH |	2-of-xpub1...-xpub2...-[legacy] |
 
 :::tip
-On top of the Xpub extended public key formats shown above, BTCPay Server supports Ypub and Zpub formats. Please note that these will be converted to Xpub once the wallet setup is completed. This has no effect on how you receive or send funds.
+On top of the xPub extended public key formats shown above, BTCPay Server supports yPub and zPub formats. Please note that these will be converted to xPub once the wallet setup is completed. This has no effect on how you receive or send funds.
 :::
 
 ## What is a Replace-By-Fee (RBF) transaction?

--- a/docs/FAQ/FAQ-Wallet.md
+++ b/docs/FAQ/FAQ-Wallet.md
@@ -33,7 +33,7 @@ This  means that you're using a hardware wallet without leaking information to t
 
 ## Do I have to use BTCPay Server wallet?
 
-By default BTCPay Server only requires an extended public key. To receive payments to your BTCPay store, you need to provide an extended public key (xpub) which you can generate in an external (existing) wallet. You do not have to use the built in wallet at all, you can manage funds in your [existing wallet](../WalletSetup.md#use-an-existing-wallet).
+By default BTCPay Server only requires an extended public key. To receive payments to your BTCPay store, you need to provide an extended public key which you can generate in an external (existing) wallet. You do not have to use the built in wallet at all, you can manage funds in your [existing wallet](../WalletSetup.md#use-an-existing-wallet).
 
 However, it's recommended to use the built in wallet for funds management. The built in wallet not only improves your privacy by default, but also solves user-experience issues like [gap-limit](#missing-payments-in-my-software-or-hardware-wallet).
 
@@ -77,9 +77,9 @@ For best user-experience and privacy, we recommend that you consider dropping ex
 
 ## What is a derivation scheme?
 
-No matter [how you set up your wallet](../WalletSetup.md), BTCPay Server uses a `derivation scheme` to represent the destination of the funds received by your invoices. The destination of those funds will be your wallet, located by the xpubkey that you provide.
+No matter [how you set up your wallet](../WalletSetup.md), BTCPay Server uses a `derivation scheme` to represent the destination of the funds received by your invoices. The destination of those funds will be your wallet, located by the extended public key that you provide.
 
-Using different derivation schemes with your xpub, you can also choose to create various receiving address types, shown in your store invoices.
+Using different derivation schemes with your extended public key, you can also choose to create various receiving address types, shown in your store invoices.
 
 |Address Type|	Example |
 |:--|:--:|

--- a/docs/FAQ/FAQ-Wallet.md
+++ b/docs/FAQ/FAQ-Wallet.md
@@ -90,6 +90,10 @@ Using different derivation schemes with your xpub, you can also choose to create
 |Multi-sig P2SH-P2WSH	| 2-of-xpub1...-xpub2...-[p2sh] |
 |Multi-sig P2SH |	2-of-xpub1...-xpub2...-[legacy] |
 
+:::tip
+On top of the Xpub extended public key formats shown above, BTCPay Server supports Ypub and Zpub formats. Please note that these will be converted to Xpub once the wallet setup is completed. This has no effect on how you receive or send funds.
+:::
+
 ## What is a Replace-By-Fee (RBF) transaction?
 
 A Replace-By-Fee (RBF) transaction is a feature of the Bitcoin protocol. Learn more about what it is, why it happens and the different types of RBF [here](https://bitcoin.stackexchange.com/a/54457/85016). 

--- a/docs/LedgerWallet.md
+++ b/docs/LedgerWallet.md
@@ -7,7 +7,7 @@ Direct Ledger Nano S integration is **no longer supported**. For Bitcoin wallets
 
 For [altcoin](./Altcoins.md) wallets, you can spend funds from your external wallet, sign a transaction within the [internal wallet](./Wallet.md) with [HD Private Key or mnemonic seed](./Wallet.md#signing-with-hd-private-key-or-mnemonic-seed) or a [hot wallet](./Wallet.md#signing-with-a-hot-wallet).
 
-To set up a new altcoin wallet, add the xpub key manually or [create a new wallet](./CreateWallet.md).
+To set up a new altcoin wallet, add the extended public key manually or [create a new wallet](./CreateWallet.md).
 :::
 
 ## Ledger Nano S Wallet Setup
@@ -28,7 +28,7 @@ This guide assumes, you have a Nano S wallet set up. To configure the Nano S, pl
 3. In BTCPay Server, Store > Settings > Wallet > Setup > Derivation Scheme > Import from Hardware Device > Ledger wallet
 4. Select the account which you want to use, in most cases it's the `Account 0`
 5. Confirm the `Export public key` on the wallet.
-6. The xpubkey will now automatically be added from Ledger to your BTCPay Server Store.
+6. The extended public key will now automatically be added from Ledger to your BTCPay Server Store.
 7. Make sure that the derivation scheme is `Enabled`
 8. Click `Continue`
 9. `Confirm` the address match in BTCPay.
@@ -38,13 +38,13 @@ Your Ledger wallet is now connected to your BTCPay. Payments go directly to Ledg
 #### Manual Setup
 
 If you have more than 20 accounts in your Ledger you might not be able to find the correct account because the select shows a maximum of 20 entries.
-In this case you can manually find the xpub for your wanted account in these steps:
+In this case you can manually find the extended public key for your wanted account in these steps:
 
 1. Open the [Ledger live app](https://shop.ledger.com/pages/ledger-live)
 2. Accounts -> choose your account
 3. Edit Account on the top right via the tool-icon
 4. In Edit Account -> ADVANCED LOGS
-5. Copy the xpub string
+5. Copy the extended public key string
 6. Paste it manually into the "DerivationScheme" textfield
 7. Continue with [Step 7 of the Quick Setup above](#quick-setup)
 

--- a/docs/ThirdPartyHosting.md
+++ b/docs/ThirdPartyHosting.md
@@ -49,11 +49,11 @@ The most significant attack vector when using a third-party host is the chance t
 
 First, a host may allow you to create [hot wallets](https://en.bitcoin.it/wiki/Hot_wallet) on their server. This gives the host complete access to your funds. They will act as a custodian of your private keys and thus your funds. This means you must trust they will not spend your funds. This type of wallet is NOT recommended for use with third-party hosts.
 
-Secondly, a malicious and technically skilled host can create a forked version of BTCPay Server and modify it to be able to either spy on your transactions or replace your [xpubkey](https://en.bitcoin.it/wiki/Deterministic_wallet_tools#Risks_of_Sharing_an_Extended_Public_Key_.28xpub.29) with their own. This means that future payments made to you may end up in this malicious party's wallet. 
+Secondly, a malicious and technically skilled host can create a forked version of BTCPay Server and modify it to be able to either spy on your transactions or replace your [extended public key](https://en.bitcoin.it/wiki/Deterministic_wallet_tools#Risks_of_Sharing_an_Extended_Public_Key_.28xpub.29) with their own. This means that future payments made to you may end up in this malicious party's wallet. 
 
-While an xpub connected wallet IS recommended for use with third-party hosts, It's impossible to know for certain, if the third party host is using a malicious fork. If you don't trust the third party host it is best to do the following:
+While a wallet connected with an extended public key IS recommended for use with third-party hosts, It's impossible to know for certain, if the third party host is using a malicious fork. If you don't trust the third party host it is best to do the following:
 
-- Do not use hot wallet on the third party server, use an xpub key
+- Do not use hot wallet on the third party server, use an extended public key
 - Use it mainly for testing, learning and getting started with BTCPay
 - Do not use it with high volume payments or extremely valuable transactions 
 
@@ -63,10 +63,10 @@ In BTCPay Server, a private key is never *required*. This means that funds are s
 If a third-party host asks for your private key or pre-generates one for you, be sure it's a scam. Never share your private key with anyone. It's called private for a reason.
 :::
 
-Xpubkey replacement attack applies to a self-hosted server as well. A malicious hacker can try to hack your server and try to replace an xpubkey.
+An extended public key replacement attack applies to a self-hosted server as well. A malicious hacker can try to hack your server and try to replace an extended public key.
 
 ### Privacy Concerns
-BTCPay Server does not allow server hosts to view the stores of other users nor have access to any personal data (except for registration email address). The xpubkey and even balances of other users can't be seen. However, as mentioned, a malicious third-party could modify that by creating a fork that can look like BTCPay Server on the front but be something completely different in reality.
+BTCPay Server does not allow server hosts to view the stores of other users nor have access to any personal data (except for registration email address). The extended public key and even balances of other users can't be seen. However, as mentioned, a malicious third-party could modify that by creating a fork that can look like BTCPay Server on the front but be something completely different in reality.
 
 The biggest concern, which happens when using a third-party host (even if the owner of a self-hosted server is not malicious) comes from the nature of the Bitcoin itself. If a user is not running a full node but instead relies on someone else's node, his transactions can be listened to by the owner of that node. Running a full node is not just a convenience that gives you features and enables privacy, it gives you better security and the right to "vote" and validate all the transactions yourself. Don't trust, verify.
 
@@ -84,7 +84,7 @@ Specifically, third-party hosts should not enable the following policies without
 - Allow non-admins to import their hot wallets to the node wallet
 - Allow non-admins to use the internal lightning node in their stores
 
-Third-party users who are granted access to an internal lightning node or hot wallet functionality to enable features such as Payjoin, should understand the risk and trust associated with [using hot wallets](./HotWallet.md) before choosing to use it. Use one of the [recommended wallets](./WalletSetup.md) which provide an xpubkey to use in your store, if you are unsure which wallet type to use.
+Third-party users who are granted access to an internal lightning node or hot wallet functionality to enable features such as Payjoin, should understand the risk and trust associated with [using hot wallets](./HotWallet.md) before choosing to use it. Use one of the [recommended wallets](./WalletSetup.md) which provide an extended public key to use in your store, if you are unsure which wallet type to use.
 
 ## Third Party Hosting FAQ
 

--- a/docs/WalletSetup.md
+++ b/docs/WalletSetup.md
@@ -11,7 +11,11 @@ There are two ways to set up a wallet in BTCPay Server:
 
 Using an existing wallet assumes that you already have an external wallet created and backed up.
 
-When using an existing wallet with BTCPay Server, you're providing an extended public key (xpub) from an externally generated wallet. Extended public key is a watch-only wallet token. Providing this public key allows BTCPay Server to generate a new address each time a new invoice is created.
+When using an existing wallet with BTCPay Server, you're providing an extended public key from an externally generated wallet. Extended public key is a watch-only wallet token. Providing this public key allows BTCPay Server to generate a new address each time a new invoice is created.
+
+:::tip
+When you input an extended public key starting with Ypub or Zpub as a derivation scheme, BTCPay Server automatically converts it to the Xpub format. This has no incidence on how you receive or send funds.
+:::
 
 :::tip
 By using an existing wallet, you can receive payments to the external wallet, without BTCPay Server knowing the wallet's private key. If a malicious attacker hacked your server and obtained the xpub, they could observe your transaction history, but cannot access the funds.

--- a/docs/WalletSetup.md
+++ b/docs/WalletSetup.md
@@ -14,7 +14,7 @@ Using an existing wallet assumes that you already have an external wallet create
 When using an existing wallet with BTCPay Server, you're providing an extended public key from an externally generated wallet. Extended public key is a watch-only wallet token. Providing this public key allows BTCPay Server to generate a new address each time a new invoice is created.
 
 :::tip
-When you input an extended public key starting with Ypub or Zpub as a derivation scheme, BTCPay Server automatically converts it to the Xpub format. This has no incidence on how you receive or send funds.
+When you input an extended public key starting with yPub or zPub as a derivation scheme, BTCPay Server automatically converts it to the xPub format. This has no incidence on how you receive or send funds.
 :::
 
 :::tip


### PR DESCRIPTION
Closes #805 

* af12968, 788b59e and bd185c6 simply replaces `Xpub` by `extended public key` in different files where feasible. 
Excludes image and link titles or adresses.
* c7a1551 Adds a `tip` in `WalletSetup.md` briefly explaining that BTCPay converts Ypub and Zpub to Xpub without incidence feature-wise.
* 741e1dc Adds another `tip` in `FAQ-Wallet.md`
* 182a1ab Replaces `Xpub` by `extended public key` where relevant

I kept this simple, as to not overwhelm users that could be uneducated to the specifics of these formats. 

It may be too simple.
Thoughts ?