### PR TITLE
Some fixes in RPI4 docs

### DIFF
--- a/docs/RPi4.md
+++ b/docs/RPi4.md
@@ -175,8 +175,14 @@ ufw default allow outgoing
 UFW needs default iptables changes and a reboot for the firewall to work:
 
 ```bash
-sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
-sudo reboot
+update-alternatives --set iptables /usr/sbin/iptables-legacy
+reboot
+```
+
+Switch back to root after rebooting:
+
+```bash
+sudo su -
 ```
 
 This command allows SSH connections from internal networks only:
@@ -200,16 +206,16 @@ ufw allow 8333/tcp
 ufw allow 9735/tcp
 ```
 
-Verify your configuration:
-
-```bash
-ufw status
-```
-
 Enable your firewall:
 
 ```bash
 ufw enable
+```
+
+Verify your configuration:
+
+```bash
+ufw status
 ```
 
 ## Setup BTCPay Server


### PR DESCRIPTION
Fixes some of the code snippets from the RPI4 docs.

- Sudo was used when configuring iptables and rebooting but the user was supposed to be root already
- `ufw status` cannot be queried before enabling it, so swapped the order of the commands. This may be troublesome since if the ssh rule was not properly configured and the user was setting this up via ssh, the connection can be terminated forcing the user to connect physically.
- Added a snipped telling the user to switch back to root after rebooting, since all the `ufw` commands are supposed to be run as root.