### PR TITLE
Remove Vuepress moneypatch

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -4,6 +4,7 @@ const slugify = require('./slugify')
 const preprocessMarkdown = resolve(__dirname, 'preprocessMarkdown')
 
 const baseUrl = 'https://docs.btcpayserver.org'
+const pageSuffix = '/'
 
 module.exports = {
   title: "BTCPay Server Docs",
@@ -30,8 +31,8 @@ module.exports = {
   },
   plugins: [
     ['vuepress-plugin-clean-urls', {
-      normalSuffix: '/',
-      indexSuffix: '/',
+      normalSuffix: pageSuffix,
+      indexSuffix: pageSuffix,
       notFoundPath: '/404.html',
     }],
     ['vuepress-plugin-code-copy', {
@@ -49,6 +50,7 @@ module.exports = {
     extendMarkdown (md) {
       md.use(implicitFigures)
     },
+    pageSuffix,
     slugify
   },
   themeConfig: {

--- a/setup-deps.sh
+++ b/setup-deps.sh
@@ -104,6 +104,3 @@ sed -ie 's$(docs/$(./$g' "$DOCS_DIR/Transmuter/README.md"
 for file in "$DOCS_DIR"/Transmuter/*.md; do
   update_external "$file" https://github.com/btcpayserver/btcTransmuter "$DOCS_DIR"/Transmuter/
 done
-
-# Monkey patch VuePress to properly handle clean URLs
-sed -ie "s%, '.html%, '/%" "$BASE_DIR/node_modules/@vuepress/markdown/lib/link.js"


### PR DESCRIPTION
Removes our moneypatch for Vuepress now that there is a release with vuejs/vuepress#2674 merged.

If the linkcheck works for the internal pages then this is good to go.