### PR TITLE
Register btcpay rewording

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,9 @@ In layman's terms, BTCPay Server is a self-hosted and automated invoicing system
 ### How is it different
 
 BTCPay Server is free, open-source, self-hostable software. 
-BTCPay Server is not a company. To use BTCPay Server, you can register an account on the [official demo](https://mainnet.demo.btcpayserver.org/Account/Login), [deploy](./Deployment.md) your own instance, or use a [third-party host](./ThirdPartyHosting.md).
+BTCPay Server is not a company. To use BTCPay Server, [deploy](./Deployment.md) your own instance, or use a [third-party host](./ThirdPartyHosting.md).
+
+ To explore what BTCPay Server has to offer, head over to the [official demo](https://mainnet.demo.btcpayserver.org/Account/Login).
 
 While using BTCPay Server, there is no third-party between a merchant and a customer. The merchant is always in full control of their funds. There are no processing or subscription fees. BTCPay Server is free to use and completely open-source, so developers or security auditors can always inspect the quality of the code.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ BTCPay Server is not a company. To use BTCPay Server, [deploy](./Deployment.md) 
 
  To explore what BTCPay Server has to offer, head over to the [official demo](https://mainnet.demo.btcpayserver.org/Account/Login).
 
-While using BTCPay Server, there is no third-party between a merchant and a customer. The merchant is always in full control of their funds. There are no processing or subscription fees. BTCPay Server is free to use and completely open-source, so developers or security auditors can always inspect the quality of the code.
+While using BTCPay Server, there is no payment processing intermediary. Accept payments directly and stay in full control of received funds. There are no processing or subscription fees. BTCPay Server is free to use and completely open-source, so developers or security auditors can always inspect the quality of the code.
 
 [![BTCPay Server Simply Explained](https://img.youtube.com/vi/dbX6qWZlxOw/mqdefault.jpg)](https://www.youtube.com/watch?v=dbX6qWZlxOw "BTCPay Server Simply Explained")
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,10 @@ In layman's terms, BTCPay Server is a self-hosted and automated invoicing system
 
 ### How is it different
 
-BTCPay is code, not a company. There is no third-party between a merchant and a customer. Merchant is always in full control of the funds. There are no processing or subscription fees. BTCPay Server is free to use and completely open-source, so developers or security auditors can always inspect the quality of the code.
+BTCPay Server is free, open-source, self-hostable software. 
+BTCPay Server is not a company. To use BTCPay Server, you can register an account on the [official demo](https://mainnet.demo.btcpayserver.org/Account/Login), [deploy](./Deployment.md) your own instance, or use a [third-party host](./ThirdPartyHosting.md).
+
+While using BTCPay Server, there is no third-party between a merchant and a customer. The merchant is always in full control of their funds. There are no processing or subscription fees. BTCPay Server is free to use and completely open-source, so developers or security auditors can always inspect the quality of the code.
 
 [![BTCPay Server Simply Explained](https://img.youtube.com/vi/dbX6qWZlxOw/mqdefault.jpg)](https://www.youtube.com/watch?v=dbX6qWZlxOw "BTCPay Server Simply Explained")
 

--- a/docs/RegisterAccount.md
+++ b/docs/RegisterAccount.md
@@ -1,6 +1,6 @@
 # (1) Register account
 
-This page relates to registering an account on a BTCPay Server instance of your own or of a third-party host.
+This page relates to registering an account on a BTCPay Server instance of your own, or using a third-party host.
 
 To register a demo account, visit the [official demo](https://mainnet.demo.btcpayserver.org/Account/Login).
 

--- a/docs/RegisterAccount.md
+++ b/docs/RegisterAccount.md
@@ -4,7 +4,7 @@ This page relates to registering an account on a BTCPay Server instance of your 
 
 To register a demo account, visit the [official demo](https://mainnet.demo.btcpayserver.org/Account/Login).
 
-To deploy an instance of your own, see [Choosing a deployment method](./Deployment.md).
+To deploy an instance of your own, see [choosing a deployment method](./Deployment.md).
 
 A non-exhaustive list of third-party hosts can be found on the BTCPay Server [directory](https://directory.btcpayserver.org/filter/hosts).
 

--- a/docs/RegisterAccount.md
+++ b/docs/RegisterAccount.md
@@ -1,5 +1,13 @@
 # (1) Register account
 
+This page relates to registering an account on a BTCPay Server instance of your own or of a third-party host.
+
+To register a demo account, visit the [official demo](https://mainnet.demo.btcpayserver.org/Account/Login).
+
+To deploy an instance of your own, see [Choosing a deployment method](./Deployment.md).
+
+A non-exhaustive list of third-party hosts can be found on the BTCPay Server [directory](https://directory.btcpayserver.org/filter/hosts).
+
 ## Account Registration
 
 The first step in setting up your BTCPay Server is creating a user account. The **first created account** on a newly-deployed BTCPay Server is automatically - **admin**.

--- a/docs/ThirdPartyHosting.md
+++ b/docs/ThirdPartyHosting.md
@@ -10,7 +10,6 @@ In layman words, think of this feature as a payment processor factory which allo
 
 Some of the hosts are entirely free to use and maintain the server cost from donations of their users. If you've been using a reliable free host for a while, you should consider donating to them to support them.
 
-Table of contents:
 - [Third-party hosting](#third-party-hosting)
   - [Advantages and disadvantages](#advantages-and-disadvantages)
     - [Pros](#pros)
@@ -125,4 +124,3 @@ Third party hosts (non-malicious) can see the following:
 Note: If additional features are enabled such as non-admin lightning wallet, hot wallets or transmuter, the server admin can see additional information related to those features. Since it's impossible to know if the third party host is using a malicious fork, it's best to assume they may know all details about your BTCPay Server usage.
 
 If you are worried about the information a third party host knows about you, please consider [deploying your own](./Deployment.md) self-hosted server.
-

--- a/docs/ThirdPartyHosting.md
+++ b/docs/ThirdPartyHosting.md
@@ -11,19 +11,20 @@ In layman words, think of this feature as a payment processor factory which allo
 Some of the hosts are entirely free to use and maintain the server cost from donations of their users. If you've been using a reliable free host for a while, you should consider donating to them to support them.
 
 Table of contents:
-- [Advantages and Disadvantages](#advantages-and-disadvantages)
-   - [Pros](#pros)
-   - [Cons](#cons)
-- [Concerns For Use](#concerns-for-use)
-   - [Security](#security-concerns)
-   - [Privacy](#privacy-concerns)
-   - [Trust](#trust-concerns)
-- [Third Party Hosting FAQ](#third-party-hosting-faq)
+- [Third-party hosting](#third-party-hosting)
+  - [Advantages and disadvantages](#advantages-and-disadvantages)
+    - [Pros](#pros)
+    - [Cons](#cons)
+  - [Concerns For Use](#concerns-for-use)
+    - [Security Concerns](#security-concerns)
+    - [Privacy Concerns](#privacy-concerns)
+    - [Trust Concerns](#trust-concerns)
+  - [Third Party Hosting FAQ](#third-party-hosting-faq)
   - [Where is the list of BTCPay third-party hosts?](#where-is-the-list-of-btcpay-third-party-hosts)
   - [How can one become a third-party host?](#how-can-one-become-a-third-party-host)
   - [Are there any limitations in features when using a third-party host?](#are-there-any-limitations-in-features-when-using-a-third-party-host)
   - [Can I enable the use of my Lightning Network node to others?](#can-i-enable-the-use-of-my-lightning-network-node-to-others)
-  - [What does the third-party host know about their users?](#what-does-the-third-party-host-know-about-their-users)
+  - [What does the trusted third-party host know about their users?](#what-does-the-trusted-third-party-host-know-about-their-users)
 
 ## Advantages and disadvantages
 
@@ -92,7 +93,9 @@ Third-party users who are granted access to an internal lightning node or hot wa
 
 Feel free to chat with the [Community](./Community.md) to find the appropriate host for your needs, but also make sure to choose one that is trustworthy. Read the rest of this document to better understand the pros and cons of using a third-party host.
 
+:::tip
 The BTCPay Server [Directory](https://directory.btcpayserver.org/filter/hosts) lists multiple free or paid third-party hosts that you can register to, to start exploring BTCPay Server.
+:::
 
 ## How can one become a third-party host?
 To become a third-party host, you need to self-host a BTCPay Server and enable registration for other users.


### PR DESCRIPTION
Hopefully closes #812 and closes #840 

* Adds wording redirecting viewers to appropriate sections. Mainly the demo official demo instance, third party hoster list (directory) or deployment page.
* Add rewording and addition in an attempt to make more clear the fact that BTCPay is not a company.
* Add `tip` mark to make directory third party hoster list more visually seen.. 