### PR TITLE
Add new supporter to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The BTCPay Server Project is proudly supported by these entities through the [BT
       </td>
       <td align="center" valign="middle">
         <a href="https://coincards.com/" target="_blank">
-          <img  src="https://raw.githubusercontent.com/btcpayserver/btcpayserver/master/BTCPayServer/wwwroot/img/coincards.svg?sanitize=true" alt="Nomics" height=100>
+          <img  src="https://raw.githubusercontent.com/btcpayserver/btcpayserver/master/BTCPayServer/wwwroot/img/coincards.svg?sanitize=true" alt="Coincards" height=100>
           <br/>
           <span>Coincards</span>
         </a>

--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ The BTCPay Server Project is proudly supported by these entities through the [BT
           <span>Nomics</span>
         </a>
       </td>
+      <td align="center" valign="middle">
+        <a href="https://coincards.com/" target="_blank">
+          <img  src="https://raw.githubusercontent.com/btcpayserver/btcpayserver/master/BTCPayServer/wwwroot/img/coincards.svg?sanitize=true" alt="Nomics" height=100>
+          <br/>
+          <span>Coincards</span>
+        </a>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/docs/README.md
+++ b/docs/README.md
@@ -180,6 +180,14 @@ If you're beginner, take a look at the step by step guide on how to contribute t
             <br/>
             <span>Nomics</span>
           </a>
+        </td>
+        </td>
+        <td align="center" valign="top" width="14.285714285714285714285714285714%">
+          <a href="https://coincards.com/" target="_blank">
+            <img  src="https://raw.githubusercontent.com/btcpayserver/btcpayserver/master/BTCPayServer/wwwroot/img/coincards.svg?sanitize=true" alt="Coincards" loading="lazy" height=100>
+            <br/>
+            <span>Coincards</span>
+          </a>
         </td> 
       </tr>
     </tbody>


### PR DESCRIPTION
- Adds a new supporter logo to the readme of docs.
- Depends on https://github.com/btcpayserver/btcpayserver/pull/2389