### PR TITLE
Docs/apps.md clarification

### DIFF
--- a/docs/Apps.md
+++ b/docs/Apps.md
@@ -21,7 +21,7 @@ The **web-based PoS app** allows users with brick and mortar stores to readily *
 
 Adding new products is easy. The app has a **shopping cart feature**, **tips**, **product inventory**, **custom payment options** and more.
 
-**Point of sale app** can also be used to receive donations, tips or even be used as a small e-shop, depending on the options or customizations applied.
+The **Point of sale app** can also be used to receive donations, tips or even be used as a small e-shop, depending on the options or customizations applied.
 
 Curently, the **Point of Sale app** supports three different views:
 * A `Static` view representing only the items for sale.

--- a/docs/Apps.md
+++ b/docs/Apps.md
@@ -21,7 +21,7 @@ The **web-based PoS app** allows users with brick and mortar stores to readily *
 
 Adding new products is easy. The app has a **shopping cart feature**, **tips**, **product inventory**, **custom payment options** and more.
 
-The **Point of sale app** can also be used to receive donations, tips or even be used as a small e-shop, depending on the options or customizations applied.
+The **Point of sale app** can also be used to receive donations, tips or even as a small e-commerce shop, depending on the options or customizations applied.
 
 Curently, the **Point of Sale app** supports three different views:
 * A `Static` view representing only the items for sale.

--- a/docs/Apps.md
+++ b/docs/Apps.md
@@ -21,7 +21,7 @@ The **web-based PoS app** allows users with brick and mortar stores to readily *
 
 Adding new products is easy. The app has a **shopping cart feature**, **tips**, **product inventory**, **custom payment options** and more.
 
-**Point of sale app** can also be used for receiving donations or even as a small e-shop, depending on the customizations applied.
+**Point of sale app** can also be used to receive donations, tips or even be used as a small e-shop, depending on the options or customizations applied.
 
 Curently, the **Point of Sale app** supports three different views:
 * A `Static` view representing only the items for sale.


### PR DESCRIPTION
Closes #894 

In a question brought up in #894 it appeared that we didn't mention explicitly `tips` as being a possible use-case of the `POS app`.
Since the `standalone donation button` is probably going to be a gonner in the future, we might as well mention it for the `POS app`.