### PR TITLE
Deprecated X-Frame-Options by MDN

### DIFF
--- a/docs/ReverseProxyToTor.md
+++ b/docs/ReverseProxyToTor.md
@@ -185,7 +185,7 @@ server {
   resolver_timeout 30s;
 
   add_header Strict-Transport-Security "max-age=63072000" always;
-  add_header X-Frame-Options SAMEORIGIN;
+  add_header Content-Security-Policy "frame-ancestors 'self';";
   add_header X-Content-Type-Options nosniff;
 
   # Proxy requests to the socat service


### PR DESCRIPTION
Note: The `Content-Security-Policy` HTTP header has a frame-ancestors directive which obsoletes the `X-Frame-Options` header for supporting browsers.

I've found that if I create a payment button and run it on a different domain, the modal will not run because of this option. With the `X-Frame-Options` you can't indicate more than one domain but you can with the `Content-Security-Policy`. For example you can use:

```
add_header Content-Security-Policy "frame-ancestors 'self' *.domain.com otherdomain.com;";
```

For more information see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options