### PR TITLE
Fix for mobile layout on firefox

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -20,6 +20,7 @@ module.exports = {
   title,
   description: "BTCPay Server Official Documentation",
   head: [
+    ['meta', { name: "viewport", content: "width=device-width, initial-scale=1.0"}],
     ["link", { rel: "stylesheet", href: "/styles/btcpayserver-variables.css" }]
   ],
   chainWebpack (config) {


### PR DESCRIPTION
related to the vuepress issue with the mobile layout removing viewport meta tags on firefox for Android.

Fix is to explicity define it.

https://github.com/vuejs/vuepress/issues/2369