### PR TITLE
R pi4 install

### DIFF
--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -93,7 +93,7 @@ The 500GB SSD allows you to keep a full copy of the Bitcoin blockchain, until it
 
 ## Install Linux on the Raspberry Pi
 
-Start by downloading the latest [64 Bit RaspiOS](https://downloads.raspberrypi.org/raspios_lite_arm64/images).  Select the most recent directory and download the zip file to your existing computer. The “Lite” distribution is fine for BTCPay setup.
+Start by downloading the latest [64 Bit RaspiOS](https://downloads.raspberrypi.org/raspios_lite_arm64/images):  Select the most recent directory and download the zip file to your existing computer. The “Lite” distribution is fine for BTCPay setup.
 
 ### Flash your SD card with the Raspberry Pi OS for Linux
 

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -11,7 +11,11 @@ Already have a Raspberry Pi 4B with the following specs?
 	- 1TB USB 3.0 SSD
 	- 16GB or greater SD card   
 
-Download the latest [64 Bit RaspiOS 64](https://downloads.raspberrypi.org/raspios_lite_arm64/images). Flash the image to your SD card.  If you don't have a keyboard and monitor make sure you enable SSH by creating empty file named "ssh" on the "boot" folder of the SD card. 
+Download the latest [64 Bit RaspiOS 64](https://downloads.raspberrypi.org/raspios_lite_arm64/images).  
+
+- Select the most recent directory and download the zip file.  
+- Flash the image to your SD card.  
+- If you don't have a keyboard and monitor make sure you enable SSH by creating empty file named "ssh" on the "boot" folder of the SD card. 
 
 Login to the RPI (the default username is "pi" and the default password is "raspberry") and run the following commands.
 
@@ -89,7 +93,7 @@ The 500GB SSD allows you to keep a full copy of the Bitcoin blockchain, until it
 
 ## Install Linux on the Raspberry Pi
 
-Start by downloading the latest [64 Bit RaspiOS](https://downloads.raspberrypi.org/raspios_lite_arm64/images) to your existing computer. The “Lite” distribution is fine for BTCPay setup.
+Start by downloading the latest [64 Bit RaspiOS](https://downloads.raspberrypi.org/raspios_lite_arm64/images).  Select the most recent directory and download the zip file to your existing computer. The “Lite” distribution is fine for BTCPay setup.
 
 ### Flash your SD card with the Raspberry Pi OS for Linux
 

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -6,11 +6,12 @@ The newly released **Raspberry Pi 4** is currently the best low-cost single-boar
 
 # Quickstart
 Already have a Raspberry Pi 4B with the following specs?
+
 	- 4GB memory
 	- 1TB USB 3.0 SSD
 	- 16GB or greater SD card   
 
-Download the latest [64 Bit RaspiOS 64](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip). Flash the image to your SD card.  If you don't have a keyboard and monitor make sure you enable SSH by creating empty file named "ssh" on the "boot" folder of the SD card. 
+Download the latest [64 Bit RaspiOS 64](https://downloads.raspberrypi.org/raspios_lite_arm64/images). Flash the image to your SD card.  If you don't have a keyboard and monitor make sure you enable SSH by creating empty file named "ssh" on the "boot" folder of the SD card. 
 
 Login to the RPI (the default username is "pi" and the default password is "raspberry") and run the following commands.
 
@@ -88,11 +89,11 @@ The 500GB SSD allows you to keep a full copy of the Bitcoin blockchain, until it
 
 ## Install Linux on the Raspberry Pi
 
-Start by downloading the latest [64 Bit RaspiOS](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip) to your existing computer. The “Lite” distribution is fine for BTCPay setup.
+Start by downloading the latest [64 Bit RaspiOS](https://downloads.raspberrypi.org/raspios_lite_arm64/images) to your existing computer. The “Lite” distribution is fine for BTCPay setup.
 
 ### Flash your SD card with the Raspberry Pi OS for Linux
 
-- Extract the downloaded `2021-05-07-raspios-buster-arm64-lite` Zip file
+- Extract the downloaded for example `2021-05-07-raspios-buster-arm64-lite` Zip file
 - Download the latest version of [balenaEtcher](https://www.balena.io/etcher/) and install it.
 - Connect an SD card reader with the SD card inside.
 - Open balenaEtcher and select from your hard drive the Raspberry Pi .img from the extracted zip file you wish to write to the SD card.

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -19,7 +19,7 @@ Change your password.
 passwd
 ```
 
-LND - Full Node (IBD takes approximately 36 hours after initial install).
+For LND Full Node - IBD takes approximately 36 hours after initial install.
 ```bash
 sudo su -
 wget -O btcpayserver-lnd-rpi4-install.sh https://raw.githubusercontent.com/btcpayserver/btcpayserver-doc/master/docs/Deployment/btcpayserver-lnd-rpi4-install.txt
@@ -27,7 +27,7 @@ chmod +x btcpayserver-lnd-rpi4-install.sh
 . btcpayserver-lnd-rpi4-install.sh
 ```
 
-C-Lightning - Full Node (IBD taxes approximately 36 hours after initial install).
+For C-Lightning Full Node - IBD taxes approximately 36 hours after initial install.
 ```bash
 sudo su -
 wget -O btcpayserver-clightning-rpi4-install.sh https://raw.githubusercontent.com/btcpayserver/btcpayserver-doc/master/docs/Deployment/btcpayserver-clightning-rpi4-install.txt

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -180,11 +180,20 @@ This is also to prevent burning out your SD card too quickly:
 echo 'none /var/log tmpfs size=10M,noatime 0 0' >> /etc/fstab
 ```
 
-Mount the SSD partition and create a symlink for docker to use the SSD:
+## Install Docker & Docker Compose
+```
+curl -sSL https://get.docker.com | sh
+apt-get install -y git build-essential python3-pip
+pip3 install docker-compose
+```
 
-```bash
-mkdir /mnt/usb/docker
-ln -s /mnt/usb/docker /var/lib/docker
+## Create mount for Docker volumes
+```
+rm -rf /var/lib/docker/volumes
+mkdir -p /var/lib/dockers/volumes
+mount --bind /mnt/usb /var/lib/docker/volumes
+echo "/mnt/usb /var/lib/docker/volumes none bind,nobootwait 0 2" >> /etc/fstab
+systemctl restart docker
 ```
 
 ## Configuring the firewall

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -4,6 +4,24 @@ This document guides you step by step on **how to run BTCPay Server on a Raspber
 
 The newly released **Raspberry Pi 4** is currently the best low-cost single-board computer available. You can **use a Raspberry Pi 4 to run your BTCPay Server** at home for around $150 worth of parts, described below.
 
+# Quickstart
+Already have a Raspberry Pi 4B with at least 4GB memory, a 1 TB USB 3.0 SSD and a 16GB or greater SD card?   
+
+Download the latest [64 Bit RaspiOS 64](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip). Flash the image to your SD card.  If you don't have a keyboard and monitor make sure you enable SSH.  Just create an empty file named "ssh" on the "boot" folder of the SD card. 
+
+Login to the RPI (the default username is "pi" and the default password is "raspberry") and run the following commands.
+ 
+```bash
+sudo su -
+wget -O btcpayserver-rpi4-install.sh https://raw.githubusercontent.com/btcpayserver/btcpayserver-doc/master/docs/Deployment/btcpayserver-rpi4-install.txt
+chmod +x btcpayserver-rip4-install.sh
+. btcpayserver-rpi4-install.sh
+```
+ 
+```bash
+grab yourself a beverage and relax whilst BTCPayServer installs
+```
+
 ## Required Hardware
 
 ### Raspberry Pi 4

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -37,6 +37,7 @@ chmod +x btcpayserver-clightning-rpi4-install.sh
 
 After initial setup is complete open a browser on another computer and go to btcpay.local 
 
+# Detailed Step by Step Instructions. 
 ## Required Hardware
 
 ### Raspberry Pi 4

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -13,6 +13,7 @@ Already have a Raspberry Pi 4B with the following specs?
 Download the latest [64 Bit RaspiOS 64](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip). Flash the image to your SD card.  If you don't have a keyboard and monitor make sure you enable SSH by creating empty file named "ssh" on the "boot" folder of the SD card. 
 
 Login to the RPI (the default username is "pi" and the default password is "raspberry") and run the following commands.
+
 Change your password. 
 ```bash
 passwd

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -97,7 +97,7 @@ Start by downloading the latest [64 Bit RaspiOS](https://downloads.raspberrypi.o
 
 ### Flash your SD card with the Raspberry Pi OS for Linux
 
-- Extract the downloaded for example `2021-05-07-raspios-buster-arm64-lite` Zip file
+- Extract the downloaded Zip file
 - Download the latest version of [balenaEtcher](https://www.balena.io/etcher/) and install it.
 - Connect an SD card reader with the SD card inside.
 - Open balenaEtcher and select from your hard drive the Raspberry Pi .img from the extracted zip file you wish to write to the SD card.

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -11,7 +11,7 @@ Already have a Raspberry Pi 4B with the following specs?
 	- 1TB USB 3.0 SSD
 	- 16GB or greater SD card   
 
-Download the latest [64 Bit RaspiOS 64](https://downloads.raspberrypi.org/raspios_lite_arm64/images).  
+Download the latest [64 Bit RaspiOS](https://downloads.raspberrypi.org/raspios_lite_arm64/images).  
 
 - Select the most recent directory and download the zip file.  
 - Flash the image to your SD card.  

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -5,13 +5,16 @@ This document guides you step by step on **how to run BTCPay Server on a Raspber
 The newly released **Raspberry Pi 4** is currently the best low-cost single-board computer available. You can **use a Raspberry Pi 4 to run your BTCPay Server** at home for around $150 worth of parts, described below.
 
 # Quickstart
-Already have a Raspberry Pi 4B with at least 4GB memory, a 1 TB USB 3.0 SSD and a 16GB or greater SD card?   
+Already have a Raspberry Pi 4B with the following specs?
+	- 4GB memory
+	- 1TB USB 3.0 SSD
+	- 16GB or greater SD card   
 
-Download the latest [64 Bit RaspiOS 64](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip). Flash the image to your SD card.  If you don't have a keyboard and monitor make sure you enable SSH.  Just create an empty file named "ssh" on the "boot" folder of the SD card. 
+Download the latest [64 Bit RaspiOS 64](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip). Flash the image to your SD card.  If you don't have a keyboard and monitor make sure you enable SSH by creating empty file named "ssh" on the "boot" folder of the SD card. 
 
 Login to the RPI (the default username is "pi" and the default password is "raspberry") and run the following commands.
 
-For LND Full Node
+LND - Full Node (IBD takes approximately 36 hours after initial install).
 ```bash
 sudo su -
 wget -O btcpayserver-lnd-rpi4-install.sh https://raw.githubusercontent.com/btcpayserver/btcpayserver-doc/master/docs/Deployment/btcpayserver-lnd-rpi4-install.txt
@@ -19,7 +22,7 @@ chmod +x btcpayserver-lnd-rpi4-install.sh
 . btcpayserver-lnd-rpi4-install.sh
 ```
 
-For C-Lightning
+C-Lightning - Full Node (IBD taxes approximately 36 hours after initial install).
 ```bash
 sudo su -
 wget -O btcpayserver-clightning-rpi4-install.sh https://raw.githubusercontent.com/btcpayserver/btcpayserver-doc/master/docs/Deployment/btcpayserver-clightning-rpi4-install.txt

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -29,10 +29,8 @@ wget -O btcpayserver-clightning-rpi4-install.sh https://raw.githubusercontent.co
 chmod +x btcpayserver-clightning-rpi4-install.sh
 . btcpayserver-clightning-rpi4-install.sh
 ```
- 
-```bash
-grab yourself a beverage and relax whilst BTCPayServer installs
-```
+
+After initial setup is complete open a browser on another computer and go to btcpay.local 
 
 ## Required Hardware
 
@@ -84,13 +82,11 @@ The 500GB SSD allows you to keep a full copy of the Bitcoin blockchain, until it
 
 ## Install Linux on the Raspberry Pi
 
-Start by downloading [Raspberry Pi OS for Linux](https://www.raspberrypi.org/software/operating-systems/) to your existing computer. The “Lite” distribution is fine for BTCPay setup, but if you want to use your Raspberry Pi for other things, you might want the full image.
-
-![RPI4 Linux Installation](../img//RPI4Linux.png "Raspberry Pi 4 Linux Installation")
+Start by downloading the latest [64 Bit RaspbiOS](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip) to your existing computer. The “Lite” distribution is fine for BTCPay setup.
 
 ### Flash your SD card with the Raspberry Pi OS for Linux
 
-- Extract the downloaded `Raspberry Pi OS for Linux` zip file
+- Extract the downloaded `2021-05-07-raspios-buster-arm64-lite` Zip file
 - Download the latest version of [balenaEtcher](https://www.balena.io/etcher/) and install it.
 - Connect an SD card reader with the SD card inside.
 - Open balenaEtcher and select from your hard drive the Raspberry Pi .img from the extracted zip file you wish to write to the SD card.

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -13,6 +13,10 @@ Already have a Raspberry Pi 4B with the following specs?
 Download the latest [64 Bit RaspiOS 64](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip). Flash the image to your SD card.  If you don't have a keyboard and monitor make sure you enable SSH by creating empty file named "ssh" on the "boot" folder of the SD card. 
 
 Login to the RPI (the default username is "pi" and the default password is "raspberry") and run the following commands.
+Change your password. 
+```bash
+passwd
+```
 
 LND - Full Node (IBD takes approximately 36 hours after initial install).
 ```bash
@@ -82,7 +86,7 @@ The 500GB SSD allows you to keep a full copy of the Bitcoin blockchain, until it
 
 ## Install Linux on the Raspberry Pi
 
-Start by downloading the latest [64 Bit RaspbiOS](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip) to your existing computer. The “Lite” distribution is fine for BTCPay setup.
+Start by downloading the latest [64 Bit RaspiOS](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip) to your existing computer. The “Lite” distribution is fine for BTCPay setup.
 
 ### Flash your SD card with the Raspberry Pi OS for Linux
 

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -249,6 +249,15 @@ Verify your configuration:
 ufw status
 ```
 
+## Change your Hostname
+```
+host_name='btcpay'
+    echo $host_name | sudo tee /etc/hostname
+    sed -i -E 's/^127.0.1.1.*/127.0.1.1\t'"$host_name"'/' /etc/hosts
+    hostnamectl set-hostname $host_name
+    systemctl restart avahi-daemon
+```
+
 ## Setup BTCPay Server
 
 Download BTCPay Server from GitHub:
@@ -263,7 +272,7 @@ cd btcpayserver-docker
 Configure BTCPay by setting some [environment variables](https://github.com/btcpayserver/btcpayserver-docker#environment-variables):
 
 ```bash
-export BTCPAY_HOST="raspberrypi.local"
+export BTCPAY_HOST="btcpay.local"
 export REVERSEPROXY_DEFAULT_HOST="$BTCPAY_HOST"
 export NBITCOIN_NETWORK="mainnet"
 export BTCPAYGEN_CRYPTO1="btc"
@@ -276,7 +285,7 @@ export BTCPAY_ENABLE_SSH=true
 If you want to use multiple hostnames, add them via the optional `BTCPAY_ADDITIONAL_HOSTS` variable:
 
 ```bash
-export BTCPAY_ADDITIONAL_HOSTS="btcpay.YourDomain.com,btcpay.local"
+export BTCPAY_ADDITIONAL_HOSTS="btcpay.YourDomain.com"
 ```
 
 In case you want to restrict access to your local network only, please note that you need to use a `.local` domain.
@@ -287,6 +296,6 @@ Run the BTCPay installation:
 . ./btcpay-setup.sh -i
 ```
 
-It should be up and running within a few minutes. Try opening http://raspberrypi.local in your web browser. If everything is correct, you will see BTCPay Server front page.
+It should be up and running within a few minutes. Try opening http://btcpay.local in your web browser. If everything is correct, you will see BTCPay Server front page.
 
 Now, you just need to wait a day or so for the Bitcoin blockchain to [sync and full verify](../FAQ/Synchronization.md). The bottom of the BTCPay Server web GUI will show a pop-up dialog box to monitor the progress.

--- a/docs/Deployment/RPi4.md
+++ b/docs/Deployment/RPi4.md
@@ -10,12 +10,21 @@ Already have a Raspberry Pi 4B with at least 4GB memory, a 1 TB USB 3.0 SSD and 
 Download the latest [64 Bit RaspiOS 64](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip). Flash the image to your SD card.  If you don't have a keyboard and monitor make sure you enable SSH.  Just create an empty file named "ssh" on the "boot" folder of the SD card. 
 
 Login to the RPI (the default username is "pi" and the default password is "raspberry") and run the following commands.
- 
+
+For LND Full Node
 ```bash
 sudo su -
-wget -O btcpayserver-rpi4-install.sh https://raw.githubusercontent.com/btcpayserver/btcpayserver-doc/master/docs/Deployment/btcpayserver-rpi4-install.txt
-chmod +x btcpayserver-rip4-install.sh
-. btcpayserver-rpi4-install.sh
+wget -O btcpayserver-lnd-rpi4-install.sh https://raw.githubusercontent.com/btcpayserver/btcpayserver-doc/master/docs/Deployment/btcpayserver-lnd-rpi4-install.txt
+chmod +x btcpayserver-lnd-rpi4-install.sh
+. btcpayserver-lnd-rpi4-install.sh
+```
+
+For C-Lightning
+```bash
+sudo su -
+wget -O btcpayserver-clightning-rpi4-install.sh https://raw.githubusercontent.com/btcpayserver/btcpayserver-doc/master/docs/Deployment/btcpayserver-clightning-rpi4-install.txt
+chmod +x btcpayserver-clightning-rpi4-install.sh
+. btcpayserver-clightning-rpi4-install.sh
 ```
  
 ```bash

--- a/docs/Deployment/btcpayserver-clightning-rpi4-install.txt
+++ b/docs/Deployment/btcpayserver-clightning-rpi4-install.txt
@@ -1,11 +1,10 @@
-
 #!/bin/bash
 # Set BTCPayServer Environment Variables
 export BTCPAY_HOST="btcpay.local"
 export REVERSEPROXY_DEFAULT_HOST="$BTCPAY_HOST"
 export NBITCOIN_NETWORK="mainnet"
 export BTCPAYGEN_CRYPTO1="btc"
-export BTCPAYGEN_LIGHTNING="lnd"
+export BTCPAYGEN_LIGHTNING="clightning"
 export BTCPAYGEN_REVERSEPROXY="nginx"
 export BTCPAYGEN_ADDITIONAL_FRAGMENTS=""
 export BTCPAY_ENABLE_SSH=true
@@ -137,6 +136,6 @@ apt update && apt upgrade -y
 apt autoremove -y
 
 # Display Onion Address
-echo "On another compouter open your browser to btcpay.local"
+echo "On another computer open your browser to btcpay.local"
 echo "or open the Tor Browser and copy and past the following .onion address."
-tail /var/lib/docker/volumes/generated_tor_servicesdir/_data/hostname
+tail /var/lib/docker/volumes/generated_tor_servicesdir/_data/BTCPayServer/hostname

--- a/docs/Deployment/btcpayserver-clightning-rpi4-install.txt
+++ b/docs/Deployment/btcpayserver-clightning-rpi4-install.txt
@@ -125,6 +125,13 @@ dphys-swapfile uninstall
 update-rc.d dphys-swapfile remove
 systemctl disable dphys-swapfile
 
+# Change Hostname
+host_name='btcpay'
+    echo $host_name | sudo tee /etc/hostname
+    sed -i -E 's/^127.0.1.1.*/127.0.1.1\t'"$host_name"'/' /etc/hosts
+    hostnamectl set-hostname $host_name
+    systemctl restart avahi-daemon
+
 # Install BTCPayServer
 cd /root
 git clone https://github.com/btcpayserver/btcpayserver-docker

--- a/docs/Deployment/btcpayserver-clightning-rpi4-install.txt
+++ b/docs/Deployment/btcpayserver-clightning-rpi4-install.txt
@@ -131,10 +131,6 @@ git clone https://github.com/btcpayserver/btcpayserver-docker
 cd btcpayserver-docker
 . btcpay-setup.sh -i
 
-# Update RaspiOS
-apt update && apt upgrade -y 
-apt autoremove -y
-
 # Display Onion Address
 echo "On another computer open your browser to btcpay.local"
 echo "or open the Tor Browser and copy and past the following .onion address."

--- a/docs/Deployment/btcpayserver-lnd-rpi4-install.txt
+++ b/docs/Deployment/btcpayserver-lnd-rpi4-install.txt
@@ -125,6 +125,13 @@ dphys-swapfile uninstall
 update-rc.d dphys-swapfile remove
 systemctl disable dphys-swapfile
 
+# Change Hostname
+host_name='btcpay'
+    echo $host_name | sudo tee /etc/hostname
+    sed -i -E 's/^127.0.1.1.*/127.0.1.1\t'"$host_name"'/' /etc/hosts
+    hostnamectl set-hostname $host_name
+    systemctl restart avahi-daemon
+
 # Install BTCPayServer
 cd /root
 git clone https://github.com/btcpayserver/btcpayserver-docker

--- a/docs/Deployment/btcpayserver-lnd-rpi4-install.txt
+++ b/docs/Deployment/btcpayserver-lnd-rpi4-install.txt
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Set BTCPayServer Environment Variables
+export BTCPAY_HOST="btcpay.local"
+export REVERSEPROXY_DEFAULT_HOST="$BTCPAY_HOST"
+export NBITCOIN_NETWORK="mainnet"
+export BTCPAYGEN_CRYPTO1="btc"
+export BTCPAYGEN_LIGHTNING="lnd"
+export BTCPAYGEN_REVERSEPROXY="nginx"
+export BTCPAYGEN_ADDITIONAL_FRAGMENTS=""
+export BTCPAY_ENABLE_SSH=true
+
+# Install Docker & Docker Compose
+curl -sSL https://get.docker.com | sh
+apt-get install -y git build-essential python3-pip
+pip3 install docker-compose
+
+# Configure External Storage
+DEVICE_NAME=""
+PARTITION_NAME=""
+MOUNT_DIR="/mnt/external"
+DOCKER_VOLUMES="/var/lib/docker/volumes"
+
+isSD=$(fdisk -l | grep -c "/dev/mmcblk0:")
+isNVMe=$(fdisk -l | grep -c "/dev/nvme0n1:")
+isUSB=$(fdisk -l | grep -c "/dev/sda:")
+
+# If booting from SD with external storage
+if [ ${isSD} -eq 1 ] && [ ${isUSB} -eq 1 ]; then
+  DEVICE_NAME="sda"
+  PARTITION_NAME="sda1"
+elif [ ${isSD} -eq 1 ] && [ ${isNVMe} -eq 1 ]; then
+  DEVICE_NAME="nvme0n1"
+  PARTITION_NAME="nvme0n1p1"
+fi
+
+if [ -n "${DEVICE_NAME}" ]; then
+mkdir -p ${MOUNT_DIR}
+sfdisk --delete /dev/${DEVICE_NAME}
+sync
+sleep 4
+sudo wipefs -a /dev/${DEVICE_NAME}
+sync
+sleep 4
+partitions=$(lsblk | grep -c "─${DEVICE_NAME}")
+if [ ${partitions} -gt 0 ]; then
+  dd if=/dev/zero of=/dev/${DEVICE_NAME} bs=512 count=1
+  sync
+fi
+partitions=$(lsblk | grep -c "─${DEVICE_NAME}")
+if [ ${partitions} -gt 0 ]; then
+  exit 1
+fi
+
+(
+echo o # Create a new empty DOS partition table
+echo n # Add a new partition
+echo p # Primary partition
+echo 1 # Partition number
+echo   # First sector (Accept default: 1)
+echo   # Last sector (Accept default: varies)
+echo w # Write changes
+) | fdisk /dev/${DEVICE_NAME}
+sync
+
+# loop until the partition gets available
+loopdone=0
+loopcount=0
+ while [ ${loopdone} -eq 0 ]
+  do
+  sleep 2
+  sync
+  loopdone=$(lsblk -o NAME | grep -c ${PARTITION_NAME})
+  loopcount=$(($loopcount +1))
+  if [ ${loopcount} -gt 10 ]; then
+    exit 1
+    fi
+ done
+
+mkfs.ext4 -F -L external /dev/${PARTITION_NAME} 
+loopdone=0
+loopcount=0
+while [ ${loopdone} -eq 0 ]
+ do
+ sleep 2
+ sync
+ loopdone=$(lsblk -o NAME,LABEL | grep -c external)
+ loopcount=$(($loopcount +1))
+ if [ ${loopcount} -gt 10 ]; then
+         exit 1
+       fi
+done
+
+UUID="$(sudo blkid -s UUID -o value /dev/${PARTITION_NAME})"
+echo "UUID=$UUID ${MOUNT_DIR} ext4 defaults,noatime,nofail 0 0" | tee -a /etc/fstab
+mount /dev/${PARTITION_NAME} ${MOUNT_DIR}
+sleep 5
+rm -rf "$DOCKER_VOLUMES"
+mkdir -p "$DOCKER_VOLUMES"
+mount --bind "$MOUNT_DIR" "$DOCKER_VOLUMES"
+echo "$MOUNT_DIR $DOCKER_VOLUMES none bind,nobootwait 0 2" >> /etc/fstab
+systemctl restart docker
+fi
+
+
+# Configure Firewall
+apt install -y ufw fail2ban
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow from 10.0.0.0/8 to any port 22 proto tcp
+ufw allow from 172.16.0.0/12 to any port 22 proto tcp
+ufw allow from 192.168.0.0/16 to any port 22 proto tcp
+ufw allow from 169.254.0.0/16 to any port 22 proto tcp
+ufw allow from fc00::/7 to any port 22 proto tcp
+ufw allow from fe80::/10 to any port 22 proto tcp
+ufw allow from ff00::/8 to any port 22 proto tcp
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw allow 8333/tcp
+ufw allow 9735/tcp
+yes | ufw enable
+
+# Disable Swapfile
+dphys-swapfile swapoff
+dphys-swapfile uninstall
+update-rc.d dphys-swapfile remove
+systemctl disable dphys-swapfile
+
+# Install BTCPayServer
+cd /root
+git clone https://github.com/btcpayserver/btcpayserver-docker
+cd btcpayserver-docker
+. btcpay-setup.sh -i
+
+# Update RaspiOS
+apt update && apt upgrade -y 
+apt autoremove -y
+
+# Display Onion Address
+echo "On another computer open your browser to btcpay.local"
+echo "or open the Tor Browser and copy and past the following .onion address."
+tail /var/lib/docker/volumes/generated_tor_servicesdir/_data/BTCPayServer/hostname

--- a/docs/Deployment/btcpayserver-lnd-rpi4-install.txt
+++ b/docs/Deployment/btcpayserver-lnd-rpi4-install.txt
@@ -131,10 +131,6 @@ git clone https://github.com/btcpayserver/btcpayserver-docker
 cd btcpayserver-docker
 . btcpay-setup.sh -i
 
-# Update RaspiOS
-apt update && apt upgrade -y 
-apt autoremove -y
-
 # Display Onion Address
 echo "On another computer open your browser to btcpay.local"
 echo "or open the Tor Browser and copy and past the following .onion address."

--- a/docs/Deployment/btcpayserver-rpi4-install.txt
+++ b/docs/Deployment/btcpayserver-rpi4-install.txt
@@ -135,3 +135,8 @@ cd btcpayserver-docker
 # Update RaspiOS
 apt update && apt upgrade -y 
 apt autoremove -y
+
+# Display Onion Address
+echo "On another compouter open your browser to btcpay.local"
+echo "or open the Tor Browser and copy and past the following .onion address."
+tail /var/lib/docker/volumes/generated_tor_servicesdir/_data/hostname

--- a/docs/Deployment/btcpayserver-rpi4-install.txt
+++ b/docs/Deployment/btcpayserver-rpi4-install.txt
@@ -104,6 +104,7 @@ fi
 
 
 # Configure Firewall
+apt install -y ufw fail2ban
 ufw default deny incoming
 ufw default allow outgoing
 ufw allow from 10.0.0.0/8 to any port 22 proto tcp

--- a/docs/Deployment/btcpayserver-rpi4-install.txt
+++ b/docs/Deployment/btcpayserver-rpi4-install.txt
@@ -1,0 +1,136 @@
+
+#!/bin/bash
+# Set BTCPayServer Environment Variables
+export BTCPAY_HOST="btcpay.local"
+export REVERSEPROXY_DEFAULT_HOST="$BTCPAY_HOST"
+export NBITCOIN_NETWORK="mainnet"
+export BTCPAYGEN_CRYPTO1="btc"
+export BTCPAYGEN_LIGHTNING="lnd"
+export BTCPAYGEN_REVERSEPROXY="nginx"
+export BTCPAYGEN_ADDITIONAL_FRAGMENTS=""
+export BTCPAY_ENABLE_SSH=true
+
+# Install Docker & Docker Compose
+curl -sSL https://get.docker.com | sh
+apt-get install -y git build-essential python3-pip
+pip3 install docker-compose
+
+# Configure External Storage
+DEVICE_NAME=""
+PARTITION_NAME=""
+MOUNT_DIR="/mnt/external"
+DOCKER_VOLUMES="/var/lib/docker/volumes"
+
+isSD=$(fdisk -l | grep -c "/dev/mmcblk0:")
+isNVMe=$(fdisk -l | grep -c "/dev/nvme0n1:")
+isUSB=$(fdisk -l | grep -c "/dev/sda:")
+
+# If booting from SD with external storage
+if [ ${isSD} -eq 1 ] && [ ${isUSB} -eq 1 ]; then
+  DEVICE_NAME="sda"
+  PARTITION_NAME="sda1"
+elif [ ${isSD} -eq 1 ] && [ ${isNVMe} -eq 1 ]; then
+  DEVICE_NAME="nvme0n1"
+  PARTITION_NAME="nvme0n1p1"
+fi
+
+if [ -n "${DEVICE_NAME}" ]; then
+mkdir -p ${MOUNT_DIR}
+sfdisk --delete /dev/${DEVICE_NAME}
+sync
+sleep 4
+sudo wipefs -a /dev/${DEVICE_NAME}
+sync
+sleep 4
+partitions=$(lsblk | grep -c "─${DEVICE_NAME}")
+if [ ${partitions} -gt 0 ]; then
+  dd if=/dev/zero of=/dev/${DEVICE_NAME} bs=512 count=1
+  sync
+fi
+partitions=$(lsblk | grep -c "─${DEVICE_NAME}")
+if [ ${partitions} -gt 0 ]; then
+  exit 1
+fi
+
+(
+echo o # Create a new empty DOS partition table
+echo n # Add a new partition
+echo p # Primary partition
+echo 1 # Partition number
+echo   # First sector (Accept default: 1)
+echo   # Last sector (Accept default: varies)
+echo w # Write changes
+) | fdisk /dev/${DEVICE_NAME}
+sync
+
+# loop until the partition gets available
+loopdone=0
+loopcount=0
+ while [ ${loopdone} -eq 0 ]
+  do
+  sleep 2
+  sync
+  loopdone=$(lsblk -o NAME | grep -c ${PARTITION_NAME})
+  loopcount=$(($loopcount +1))
+  if [ ${loopcount} -gt 10 ]; then
+    exit 1
+    fi
+ done
+
+mkfs.ext4 -F -L external /dev/${PARTITION_NAME} 
+loopdone=0
+loopcount=0
+while [ ${loopdone} -eq 0 ]
+ do
+ sleep 2
+ sync
+ loopdone=$(lsblk -o NAME,LABEL | grep -c external)
+ loopcount=$(($loopcount +1))
+ if [ ${loopcount} -gt 10 ]; then
+         exit 1
+       fi
+done
+
+UUID="$(sudo blkid -s UUID -o value /dev/${PARTITION_NAME})"
+echo "UUID=$UUID ${MOUNT_DIR} ext4 defaults,noatime,nofail 0 0" | tee -a /etc/fstab
+mount /dev/${PARTITION_NAME} ${MOUNT_DIR}
+sleep 5
+rm -rf "$DOCKER_VOLUMES"
+mkdir -p "$DOCKER_VOLUMES"
+mount --bind "$MOUNT_DIR" "$DOCKER_VOLUMES"
+echo "$MOUNT_DIR $DOCKER_VOLUMES none bind,nobootwait 0 2" >> /etc/fstab
+systemctl restart docker
+fi
+
+
+# Configure Firewall
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow from 10.0.0.0/8 to any port 22 proto tcp
+ufw allow from 172.16.0.0/12 to any port 22 proto tcp
+ufw allow from 192.168.0.0/16 to any port 22 proto tcp
+ufw allow from 169.254.0.0/16 to any port 22 proto tcp
+ufw allow from fc00::/7 to any port 22 proto tcp
+ufw allow from fe80::/10 to any port 22 proto tcp
+ufw allow from ff00::/8 to any port 22 proto tcp
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw allow 8333/tcp
+ufw allow 9735/tcp
+yes | ufw enable
+
+# Disable Swapfile
+dphys-swapfile swapoff
+dphys-swapfile uninstall
+update-rc.d dphys-swapfile remove
+systemctl disable dphys-swapfile
+
+# Install BTCPayServer
+cd /root
+git clone https://github.com/btcpayserver/btcpayserver-docker
+cd btcpayserver-docker
+. btcpay-setup.sh -i
+
+# Update RaspiOS
+apt update && apt upgrade -y 
+apt autoremove -y


### PR DESCRIPTION
Updated the Raspberry Pi 4 instructions.
1. Use 64 Bit RaspiOS. 
2. Added "quick-start" installation scripts for LND & CLightning "full nodes".
3. Changed hostname to btcpay.
4. Changed symlink for docker volumes to "mount --bind".  