### PR TITLE
Fix “ssl” Directive Is Deprecated

### DIFF
--- a/docs/Deployment/ReverseProxyToTor.md
+++ b/docs/Deployment/ReverseProxyToTor.md
@@ -171,7 +171,6 @@ server {
   server_name mydomain.com;
 
   # SSL settings
-  ssl on;
   ssl_stapling on;
   ssl_stapling_verify on;
 
@@ -216,6 +215,7 @@ systemctl restart nginx
 ```
 
 Now, visiting `mydomain.com` should show your BTCPay Server instance.
+
 
 
 ## Do all this in a Docker container


### PR DESCRIPTION
Fix “ssl” Directive Is Deprecated, Use “listen … ssl”

The deprecation warning tells you to reconfigure your SSL settings. In nginx 1.10 (and below) you configured SSL using the ssl on;
This setting changed in nginx 1.12 (and above). You now need to configure SSL in the same line as the listen statement. 

Simple fix. Remove the "ssl on" completely

Thanks for the otherwise great tutorial, everything worked out fine after this simple fix!