### PR TITLE
Adding link to BTCPay for WooCommerce V2 video.

### DIFF
--- a/docs/WooCommerce.md
+++ b/docs/WooCommerce.md
@@ -17,6 +17,10 @@ This guide refers to the BTCPay for WooCommerce V2 plugin. You can find instruct
 
 ![BTCPay - WooCommerce Infographic](./img/infographics/BTCPayInfographic.png "BTCPay - WooCommerce Infographic")
 
+To integrate BTCPay Server into an existing WooCommerce store, follow the steps below and/or watch this video:
+
+[![BTCPay - WooCommerce](https://img.youtube.com/vi/tTH3nLoyTcw/mqdefault.jpg)](https://www.youtube.com/watch?v=a-MQHgnjNXI "BTCPay for WooCommerce V2 Installation")
+
 ## Requirements
 
 Please ensure that you meet the following requirements before installing this plugin.

--- a/docs/WooCommerce.md
+++ b/docs/WooCommerce.md
@@ -19,7 +19,7 @@ This guide refers to the BTCPay for WooCommerce V2 plugin. You can find instruct
 
 To integrate BTCPay Server into an existing WooCommerce store, follow the steps below and/or watch this video:
 
-[![BTCPay - WooCommerce](https://img.youtube.com/vi/tTH3nLoyTcw/mqdefault.jpg)](https://www.youtube.com/watch?v=a-MQHgnjNXI "BTCPay for WooCommerce V2 Installation")
+[![BTCPay - WooCommerce](https://img.youtube.com/vi/ULcocDKZ1Mw/mqdefault.jpg)](https://www.youtube.com/watch?v=ULcocDKZ1Mw "BTCPay for WooCommerce V2 Installation")
 
 ## Requirements
 


### PR DESCRIPTION
@NicolasDorier I saw you removed the old video [here](https://github.com/btcpayserver/btcpayserver-doc/commit/d4eecd82a811500407770ab97e5dd8fd3fd64a5f) but I just forgot to update the link to the new video. Somebody is also working on improving my video so there will be a better one in the next few days and I will reopen the PR.

