### PR TITLE
Replace outdated Monero notes on altcoin FAQ

### DIFF
--- a/docs/FAQ/Altcoin.md
+++ b/docs/FAQ/Altcoin.md
@@ -19,7 +19,7 @@ Bitcoin is the only focus of the project and its core developers. However, opt i
 - Liquid Bitcoin (LBTC) (comes with Liquid Tether support USDt) [(notes on deployment & usage)](https://github.com/btcpayserver/btcpayserver/issues/1282)
 - Litecoin (LTC)
 - Monacoin (MONA)
-- Monero (XMR) [(notes on deployment)](https://github.com/btcpayserver/btcpayserver-docker/issues/204#issuecomment-552755422)
+- Monero (XMR) [(guide on deployment and usage)](https://sethforprivacy.com/guides/accepting-monero-via-btcpay-server/)
 - Polis (POLIS)
 - Viacoin (VIA)
 


### PR DESCRIPTION
This replaces the outdated notes for Monero usage with an up-to-date guide on the process of accepting Monero via BTCPay Server from start to finish:

https://sethforprivacy.com/guides/accepting-monero-via-btcpay-server/