### PR TITLE
Add workflow_dispatch trigger to allow manual builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
   repository_dispatch:
     types:
       - build_docs
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
The linkcheck fails quite often due to temporarily unavailable pages. To avoid doing a commit to re-trigger the check and build it might be good to be able to manually trigger a build via the UI, seems this trigger can do just that. See https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

Feel free to close the PR if you do not think this is useful.
