### PR TITLE
Update WooCommerce Troubleshooting / Webhooks

### DIFF
--- a/docs/WooCommerce.md
+++ b/docs/WooCommerce.md
@@ -217,7 +217,9 @@ By default type "payment" is selected. But if you have Liquid Assets with your o
 # Troubleshooting
 
 ## The order states do not update although the invoice has been paid
-Please check the details of your invoice if there were any errors on sending the webhook request. Some hosting providers, firewall setups or WordPress security plugins block POST requests to your WordPress site which lead to a http status of "403 forbidden". 
+Please check first if the webhook is created under the BTCPay Server store settings. If there is no webhook created you can visit on your WooCommerce store BTCPay Settings tab under WooCommerce settings and hit the save button. This will create the webhook.
+
+You may also check the details of your invoice if there were any errors on sending the webhook request. Some hosting providers, firewall setups or WordPress security plugins block POST requests to your WordPress site which lead to a http status of "403 forbidden". 
 
 You can check and verify yourself if there is something blocking requests to your site in one of these two ways:
 


### PR DESCRIPTION
Added on troubleshooting for checking first if the Webhooks is created on the BTCPay Server under store settings.
On my case it was failing and no Webhooks was created.