### PR TITLE
Update Hardware as a Service page

### DIFF
--- a/docs/Deployment/HardwareAsAService.md
+++ b/docs/Deployment/HardwareAsAService.md
@@ -19,7 +19,7 @@ Here you can find a non-exhaustive list of companies that provide such a service
 - [Hack0](https://www.dglab.com/en/works/hack0/)
 - [LightningInABox](https://lightninginabox.co/)
 - [MyNode](https://mynodebtc.com/)
-- [RaspiBlitz](https://shop.fulmo.org/raspiblitz/)
+- [RaspiBlitz](https://raspiblitz.org/)
 - [Umbrel](https://umbrel.com/)
 - [Embassy](https://start9.com/)
 - [Citadel](https://runcitadel.space/)

--- a/docs/Deployment/HardwareAsAService.md
+++ b/docs/Deployment/HardwareAsAService.md
@@ -20,8 +20,9 @@ Here you can find a non-exhaustive list of companies that provide such a service
 - [LightningInABox](https://lightninginabox.co/)
 - [MyNode](https://mynodebtc.com/)
 - [RaspiBlitz](https://shop.fulmo.org/raspiblitz/)
-- [Umbrel](https://umbrel.com/) - **Selling products via BTCPay on Umbrel violates Umbrel's license, so you may want to choose something else**
+- [Umbrel](https://umbrel.com/)
 - [Embassy](https://start9.com/)
+- [Citadel](https://runcitadel.space/)
 
 Do you provide Hardware As A Service and are not listed here?
 Open an issue to [get added to this list](https://github.com/btcpayserver/btcpayserver-doc/issues)

--- a/docs/Deployment/HardwareAsAService.md
+++ b/docs/Deployment/HardwareAsAService.md
@@ -20,7 +20,7 @@ Here you can find a non-exhaustive list of companies that provide such a service
 - [LightningInABox](https://lightninginabox.co/)
 - [MyNode](https://mynodebtc.com/)
 - [RaspiBlitz](https://shop.fulmo.org/raspiblitz/)
-- [Umbrel](https://getumbrel.com/)
+- [Umbrel](https://umbrel.com/) - **Selling products via BTCPay on Umbrel violates Umbrel's license, so you may want to choose something else**
 - [Embassy](https://start9.com/)
 
 Do you provide Hardware As A Service and are not listed here?


### PR DESCRIPTION
This updates the Umbrel link to their latest website.

Also, a warning should be added for Umbrel. A lot of people are running a shop on Umbrel without realizing Umbrel prohibts commercial use of their software. Using an Umbrel node to sell anything is commercial use.