### PR TITLE
Add Greenfield auth and development docs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -234,6 +234,7 @@ const sidebarDevelopment = [
     collapsable: false,
     children: [
       [`${baseUrl}/API/Greenfield/v1`, 'Greenfield API v1', { type: 'external' }],
+      '/BTCPayServer/greenfield-authorization',
       '/Development/GreenFieldExample'
     ]
   },
@@ -243,6 +244,7 @@ const sidebarDevelopment = [
     children: [
       '/Development/',
       '/Development/LocalDevelopment',
+      ['/BTCPayServer/greenfield-development', 'Greenfield API Development'],
       '/Development/Altcoins',
       '/Development/Theme'
     ]

--- a/setup-deps.sh
+++ b/setup-deps.sh
@@ -41,6 +41,7 @@ cd "$BTCPAYSERVER_DIR"
 
 cp SECURITY.md "$DOCS_DIR/BTCPayServer/Security.md"
 cp BTCPayServer.Tests/README.md "$DOCS_DIR/BTCPayServer/LocalDevSetup.md"
+cp -r docs/* "$DOCS_DIR/BTCPayServer"
 line=$(grep -n '## How to manually test payments' $DOCS_DIR/BTCPayServer/LocalDevSetup.md | cut -d ":" -f 1)
 { echo $'---\neditLink: https://github.com/btcpayserver/btcpayserver-doc/edit/master/docs/Development/LocalDev.md\n---\n'; cat "$DOCS_DIR/Development/LocalDev.md"; echo; tail -n +$line "$DOCS_DIR/BTCPayServer/LocalDevSetup.md"; } > "$DOCS_DIR/Development/LocalDevelopment.md"
 


### PR DESCRIPTION
Found them and saw that they weren't part of the docs website.