### PR TITLE
Quick update.

### DIFF
--- a/docs/Deployment/btcpayserver-rpi4-install.md
+++ b/docs/Deployment/btcpayserver-rpi4-install.md
@@ -1,4 +1,5 @@
-#!/bin/bash
+# Deployment variables & commands for rpi4 install.
+This page is subjected to change and is not recommended for guide purposes; please refer to [Raspberry 4 deployment here](./RaspberryPi4.md)
 
 # Set BTCPayServer Environment Variables
 export BTCPAY_HOST="$(hostname).local"


### PR DESCRIPTION
Yooo

this page seems unnecessary compared to rpi4 deployment page. For now, at least fixed styling + notice at the top of the page to use the right guide.

input requested @pavlenex / @dennisreimann  to remove this page completely. 
