### PR TITLE
Updated "Contribute" page

### DIFF
--- a/docs/Contribute/Agenda.md
+++ b/docs/Contribute/Agenda.md
@@ -3,23 +3,13 @@
 BTCPay Server operates as an open-organization. All of our meetings where we discuss the development, design, documentation or other topics are opened for anyone to join in and participate. To get involved, you can subscribe to our open-calendar and stay in the loop on what we're working on, learn, ask questions or just join us in building open-source bitcoin payment rails.
 Follow the steps below to add the BTCPay Server `Open Community Calls` calendar to your own. 
 
-## Upcoming calls
-
-| Topic        | Direct link                                                                                        |
-|--------------|-----------:|
-| Development  | [Link](https://github.com/btcpayserver/organization/issues?q=is%3Aissue+is%3Aopen+%27Dev%27)       |
-| Design       | [Link](https://github.com/btcpayserver/organization/issues?q=is%3Aissue+is%3Aopen+%27Design%27+)   |
-| Documentation| [Link](https://github.com/btcpayserver/organization/issues?q=is%3Aissue+is%3Aopen+%27Marketing%27) |
-
 ## BTCPay Server Open Community Calls calendar
 
-Our calendar (an .iCal file) includes upcoming calls. Qualified issues are automatically added to the calendar, which you can then subscribe to via your favorite calendar tool.
+Qualified issues are automatically added to the calendar, which you can then subscribe to via your favorite calendar tool.
 
-* Copy this URL: https://raw.githubusercontent.com/btcpayserver/organization/calendar/events.ical
-* In Apple Calendar (desktop), use File -> New calendar subscriptions
-* In Google Calendar (web), click the small + icon next to Other calendars in the sidebar and select From URL
-* Paste the URL and save. New events (if there are any scheduled) should show up right away
-* In Thunderbird (desktop), New Calendar > On my network > iCalendar (ICS) and paste the calendar link in the location field.
+* In Apple Calendar (desktop), use File -> New calendar subscriptions and paste this [iCal format public address](https://calendar.google.com/calendar/ical/1m0qsj2dg72pisr9ku91qi1v28%40group.calendar.google.com/public/basic.ics)
+* In Google Calendar (web), click the sidebar "+" icon next to "Other calendars" -> select "From URL" -> Paste this [URL](https://calendar.google.com/calendar/embed?src=1m0qsj2dg72pisr9ku91qi1v28%40group.calendar.google.com&ctz=Europe%2FParis) and Save
+* In Thunderbird (desktop), use File -> New -> Calendar > On my network and paste the [iCal link](https://calendar.google.com/calendar/ical/1m0qsj2dg72pisr9ku91qi1v28%40group.calendar.google.com/public/basic.ics) in the location field.
 * Calendar tools regularly reload subscribed calendars for updates. How often this happens varies by tool.
 
 How to add the Raw link to agenda on IOS. 


### PR DESCRIPTION
Updating the obsolete GitHub links following the transition to Google calendar. 

Change overview:
- updated the links under “BTCPay Server Open Community Calls calendar”
- removed the “Upcoming calls” section since the links were no longer valid