### PR TITLE
Shopware integration page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -104,7 +104,7 @@ const sidebarUserGuide = [
       ['/OpenCart', 'OpenCart'],
       ['/Drupal', 'Drupal'],
       ['/Zapier/', 'Zapier'],
-      ['https://github.com/lampsolutions/LampSBtcPayShopware', 'Shopware', { type: 'external' }],
+      ['/Shopware', 'Shopware'],
       ['/VirtueMart', 'VirtueMart'],
       ['/CustomIntegration', 'Custom Integration']
     ]

--- a/docs/.vuepress/redirects.js
+++ b/docs/.vuepress/redirects.js
@@ -27,7 +27,7 @@ module.exports = [
     path: "/deployment/googleclouddeployment",
     redirect: "/Deployment/GoogleCloud/",
   },
-  { 
+  {
     path: "/deployment/manualdeployment",
     redirect: "/Deployment/ManualDeployment/" },
   {
@@ -116,6 +116,7 @@ module.exports = [
   { path: "/integrations/prestashop", redirect: "/PrestaShop/" },
   { path: "/integrations/virtuemart", redirect: "/VirtueMart/" },
   { path: "/integrations/opencart", redirect: "/OpenCart/" },
+  { path: "/integrations/shopware", redirect: "/Shopware/" },
   { path: "/integrations/customintegration", redirect: "/CustomIntegration/" },
   // Development
   { path: "/development", redirect: "/Development/Architecture/" },

--- a/docs/Shopware.md
+++ b/docs/Shopware.md
@@ -1,0 +1,14 @@
+# Shopware integration
+
+:::warning
+Please be aware that those two integrations are not maintained by the BTCPay Server team. If you have any questions, please go to their GitHub issues and contact them directly.
+:::
+
+## Plugin for Shopware 6
+
+Find it on the [Shopware store](https://store.shopware.com/en/coinc71249255720f/accept-bitcoin-and-lightning-payments-via-btcpay-server.html) or download it on [GitHub](https://github.com/coincharge-io/CoinchargeBTCPayShopware)
+
+## Plugin for Shopware 5
+
+Download it on [GitHub](https://github.com/lampsolutions/LampSBtcPayShopware)
+


### PR DESCRIPTION
Removed the direct link to the external Shopware 5 plugin as there is now a new Shopware 6 plugin done by coincharge.io. I created a new page and linked both. See also the discussion on mattermost [here](https://chat.btcpayserver.org/btcpayserver/pl/8duuxx187bny9mx9tpyspdtjpy)