### PR TITLE
Remove Shopware marketplace listing for now.

### DIFF
--- a/docs/Shopware.md
+++ b/docs/Shopware.md
@@ -6,7 +6,7 @@ Please be aware that those two integrations are not maintained by the BTCPay Ser
 
 ## Plugin for Shopware 6
 
-Find it on the [Shopware store](https://store.shopware.com/en/coinc71249255720f/accept-bitcoin-and-lightning-payments-via-btcpay-server.html) or download it on [GitHub](https://github.com/coincharge-io/CoinchargeBTCPayShopware)
+Download it on [GitHub](https://github.com/coincharge-io/CoinchargeBTCPayShopware)
 
 ## Plugin for Shopware 5
 


### PR DESCRIPTION
Shopware delisted the plugin in their marketplace because they wanted to charge a 2000,- EUR fee per year even it is an open source and free of charge extension. Crazy.