### PR TITLE
error handline of failed unmount

### DIFF
--- a/scripts/btcpayserver-rpi4-install.sh
+++ b/scripts/btcpayserver-rpi4-install.sh
@@ -34,10 +34,12 @@ if [ ${isSD} -eq 1 ] && [ ${isUSB} -eq 1 ]; then
   DEVICE_NAME="sda"
   PARTITION_NAME="sda1"
   umount /dev/sda1
+  findmnt /dev/sda1 >/dev/null 2>&1 && { echo -e "\nUnable to unmount /dev/sda1 - Please ensure the device is not busy and try again. Aborting." ; exit ; }
 elif [ ${isSD} -eq 1 ] && [ ${isNVMe} -eq 1 ]; then
   DEVICE_NAME="nvme0n1"
   PARTITION_NAME="nvme0n1p1"
   umount /dev/nvme0n1p1
+  findmnt /dev/nvme0n1p1 >/dev/null 2>&1 && { echo -e "\nUnable to unmount /dev/nvme0n1p1 - Please ensure the device is not busy and try again. Aborting." ; exit ; }
 fi
 
 if [ -n "${DEVICE_NAME}" ]; then


### PR DESCRIPTION
For sda1 and nvme0n1p1

If the device fails to unmount, say due to a busy device, the code will get to the end but will fail. The user has to wait a long time to get the failed feedback. Better to exit immediately. 

SUGGESTION...
It might be worth doing the error check earlier by moving the unmounting procedure before apt update/upgrade and before docker install.