### PR TITLE
Clarify NBXplorer connection string settings

### DIFF
--- a/docs/Deployment/ManualDeploymentExtended.md
+++ b/docs/Deployment/ManualDeploymentExtended.md
@@ -840,13 +840,6 @@ Updating could break things. Be careful on a live system.
 ~$ sudo systemctl start nbxplorer
 ```
 
-##### Migration
-
-With BTCPay Server v1.5 we [improved NBXplorer by switching to Postgres](https://blog.btcpayserver.org/nbxplorer-postgres/).
-If you are still using the DBTrie based version, please consider [migrating NBXplorer](https://github.com/dgarage/NBXplorer/blob/master/docs/Postgres-Migration.md).
-
-Afterwards you need to set `BTCPAY_EXPLORERPOSTGRES` to the same connection string as NBXplorer.
-
 ## BTCPay Server
 
 Like NBXplorer the BTCPay Server application is also .NET Core. The install steps assume .NET Core was previosuly installed.
@@ -905,6 +898,8 @@ explorer.postgres=User ID=nbxplorer;Password=urpassword;Application Name=nbxplor
 ~$ sudo cp btcpay.config /etc/btcpay
 ~$ sudo chmod 644 /etc/btcpay/btcpay.config
 ```
+
+Alternatively, you can start BTCPay Server using a configuration file, environment variables (`BTCPAY_EXPLORERPOSTGRES` and `BTCPAY_POSTGRES`), or command-line arguments (`--explorerpostgres` and `--postgres`).
 
 ##### 4. Create a systemd service
 


### PR DESCRIPTION
A user got confused about the lack of chart.
Given that migrations now shouldn't happen, I removed a paragraph and clarified the configuration file's settings of BTCPay Server.

[Another PR](https://github.com/btcpayserver/btcpayserver/pull/6507) improve BTCPay's instructions and update the doc link.

See https://github.com/dgarage/NBXplorer/issues/500