### PR TITLE
Use fullchain.pem in ManualDeploymentExtended.md

### DIFF
--- a/docs/Deployment/ManualDeploymentExtended.md
+++ b/docs/Deployment/ManualDeploymentExtended.md
@@ -271,7 +271,7 @@ server {
         ssl_session_timeout 5m;
         ssl_session_cache shared:SSL:50m;
         ssl_session_tickets off;
-        ssl_certificate /etc/letsencrypt/live/mainnet.demo.btcpayserver.org/cert.pem;
+        ssl_certificate /etc/letsencrypt/live/mainnet.demo.btcpayserver.org/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/mainnet.demo.btcpayserver.org/privkey.pem;
         ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
         ssl_stapling on;


### PR DESCRIPTION
Update documentation to use fullchain.pem for the `ssl_certificate` option. See https://github.com/btcpayserver/btcpayserver/issues/6532 for details.
