### PR TITLE
docs: remove stale Wabisabi sidebar entry

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -160,7 +160,6 @@ const sidebarUserGuide = [
       ['/SideShift/', 'SideShift'],
       ['/TicketTailor/', 'TicketTailor'],
       ['/Trocador/', 'Trocador'],
-      ['/Wabisabi/', 'Wabisabi Coinjoin']
     ]
   },
   {


### PR DESCRIPTION
## Summary
- remove the stale Wabisabi Coinjoin sidebar item
- stop advertising a plugin page that is no longer available
- keep the separate Wasabi Wallet setup guide intact

Closes #1531

## Testing
- not run (sidebar config change only)