### PR TITLE
Fix existing Bitcoin node Docker example to require NBXplorer

### DIFF
--- a/docs/FAQ/Deployment.md
+++ b/docs/FAQ/Deployment.md
@@ -384,6 +384,9 @@ services:
       NBXPLORER_BTCNODEENDPOINT: host.docker.internal:39388
     volumes:
       - 'localBitcoinfolder:/root/.bitcoin'
+
+required:
+  - "nbxplorer"
 ```
 
 - Replace: `43782` with your bitcoin node's configured RPC port
@@ -402,7 +405,7 @@ extra_hosts:
   - 'host.docker.internal:$DOCKER_HOST_IP'
 ```
 
-- Run `export BTCPAYGEN_EXCLUDE_FRAGMENTS="bitcoin"`
+- Run `export BTCPAYGEN_EXCLUDE_FRAGMENTS="$BTCPAYGEN_EXCLUDE_FRAGMENTS;bitcoin"`
 - Run `export BTCPAYGEN_ADDITIONAL_FRAGMENTS="$BTCPAYGEN_ADDITIONAL_FRAGMENTS;bitcoin.custom"`
 - Run `. ./btcpay-setup.sh -i`
 


### PR DESCRIPTION
## Summary
- Add the missing `required: - "nbxplorer"` dependency to the `bitcoin.custom.yml` example used when deploying BTCPay alongside an existing Bitcoin node. Excluding the standard `bitcoin` fragment also drops that dependency, so without it NBXplorer is omitted from the generated Compose config.
- Append to `BTCPAYGEN_EXCLUDE_FRAGMENTS` instead of overwriting it, matching the existing `BTCPAYGEN_ADDITIONAL_FRAGMENTS` pattern so prior excludes are preserved.

## Test plan
- [ ] Follow the "deploy alongside existing Bitcoin node" FAQ steps with a custom fragment that includes `required: - "nbxplorer"`
- [ ] Confirm `nbxplorer` appears in `docker compose -f docker-compose.generated.yml config --services`
- [ ] Confirm an existing `BTCPAYGEN_EXCLUDE_FRAGMENTS` value is preserved after running the documented export


Made with [Cursor](https://cursor.com)