### PR TITLE
docs: fix minor typos

### DIFF
--- a/docs/EasyDigitalDownloads.md
+++ b/docs/EasyDigitalDownloads.md
@@ -102,7 +102,7 @@ You will get redirected to BTCPay Server and qr-code for the invoice will be sho
 After you paid the invoice you can go back to your site:
 ![Bitcoin for EDD: Test purchase invoice paid](./img/edd/edd-checkout-invoice-paid.png)
 
-You will see the order confirmation page, with a completed payment satus:
+You will see the order confirmation page, with a completed payment status:
 ![Bitcoin for EDD: Test purchase redirect order confirmation](./img/edd/edd-checkout-invoice-paid.png)
 
 On admin backend under "_Downloads_" -> _"Orders"_ you will also see the order is completed:

--- a/docs/ElectrumWallet.md
+++ b/docs/ElectrumWallet.md
@@ -46,7 +46,7 @@ From the multiple choice menu, select `SegWit` and `Next`
 
 ![ElectrumWallet](./img/ElectrumWallet4.png)
 
-**IMPORTANT NOTE:** If you're a merchant, instead of SegWit (Bech32), it's recommended to use SegWit wrapped (P2SH) format. [This guide](https://www.youtube.com/watch?v=-1DBJWwA2Cw) explains how to create P2SH wallet in Electrum that's more suited for merchants, due to compatability with legacy wallets customers use.
+**IMPORTANT NOTE:** If you're a merchant, instead of SegWit (Bech32), it's recommended to use SegWit wrapped (P2SH) format. [This guide](https://www.youtube.com/watch?v=-1DBJWwA2Cw) explains how to create P2SH wallet in Electrum that's more suited for merchants, due to compatibility with legacy wallets customers use.
 
 **IMPORTANT NOTE 2:** Write down your recovery words in the order you see them on the screen. Write them down a piece of paper and store it somewhere secure. Take your time and triple check each word. Do not store your seed in a digital format (photograph, text document). Whoever has the access to your seed can access your funds. Confirm that the seed has been properly backed up by re-entering it in the same order. Once the seed is validated, proceed to the next step.
 

--- a/docs/VirtueMart.md
+++ b/docs/VirtueMart.md
@@ -138,7 +138,7 @@ The store ID of your BTCPay Server store. Can be found on the store settings pag
 
 **Webhook Secret**
 
-The wehbook secret which was generated on webhook createion, see [here](#23-create-a-webhook-on-btcpay-server)
+The webhook secret which was generated on webhook creation, see [here](#23-create-a-webhook-on-btcpay-server)
 
 **Webhook callback URL**
 

--- a/docs/WooCommerce.md
+++ b/docs/WooCommerce.md
@@ -198,7 +198,7 @@ This option is helpful in case you have a problem and need more information on w
 
 ### 4.2 Payment Gateway specific
 
-Depending on wheter you have above mentioned "Separate Payment Gateways" enabled you will have one or more Payment Gateways available to configure in the payment gateway settings via _WooCommerce -> Settings -> Tab [Payments]_
+Depending on whether you have above mentioned "Separate Payment Gateways" enabled you will have one or more Payment Gateways available to configure in the payment gateway settings via _WooCommerce -> Settings -> Tab [Payments]_
 
 On all payment gateways you can set the following options:
 


### PR DESCRIPTION
- Fix a few minor typos in the documentation.
- Keep the changes limited to wording corrections only.
