### PR TITLE
Fix 22 dead sidebar entries in Integrations and Plugins sections

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -116,31 +116,20 @@ const sidebarUserGuide = [
     title: 'Integrations',
     collapsable: false,
     children: [
-      ['/BigCommerce/', 'Big Commerce'],
       ['/Calcom', 'Cal.com'],
-      ['/Drupal/', 'Drupal'],
       ['/EasyDigitalDownloads', 'Easy Digital Downloads'],
       ['/EasyWebshop', 'EasyWebshop'],
-      ['/Ecwid/', 'Ecwid'],
       ['/GiveWP', 'GiveWP'],
-      ['/Grandnode/', 'Grandnode'],
       ['/InvoiceNinja', 'Invoice Ninja'],
       ['/Magento', 'Magento'],
-      ['/Nopcommerce/', 'Nopcommerce'],
-      ['/Odoo/', 'Odoo'],
       ['/OpenCart', 'OpenCart'],
       ['/PhocaCart', 'PhocaCart'],
       ['/PrestaShop', 'PrestaShop'],
       ['/Pretix', 'Pretix'],
       ['/ShopifyV2', 'Shopify V2'],
       ['/Shopware', 'Shopware'],
-      ['/Ghost/', 'Ghost'],
-      ['/Smartstore/', 'Smartstore'],
       ['/VirtueMart', 'VirtueMart'],
-      ['/Wix/', 'Wix'],
       ['/WooCommerce', 'WooCommerce'],
-      ['/Xenforo/', 'Xenforo'],
-      ['/Zapier/', 'Zapier'],
       ['/CustomIntegration', 'Custom Integration']
     ]
   },
@@ -149,18 +138,7 @@ const sidebarUserGuide = [
     collapsable: false,
     initialOpenGroupIndex: -1,
     children: [
-      [`https://dev.blink.sv/examples/btcpayserver-plugin`, 'Blink', { type: 'external' }],
-      ['/Breez/', 'Breez'],
-      ['/Bringin/', 'Bringin'],
-      ['/DynamicReports/', 'Dynamic Reports'],
-      ['/LNDhubAPI/', 'LNDhub API'],
-      ['/Nostr/', 'Nostr'],
-      ['/VendorPay/', 'Vendor Pay'],
-      ['/PodServer/', 'PodServer'],
-      ['/SideShift/', 'SideShift'],
-      ['/TicketTailor/', 'TicketTailor'],
-      ['/Trocador/', 'Trocador'],
-      ['/Wabisabi/', 'Wabisabi Coinjoin']
+      [`https://dev.blink.sv/examples/btcpayserver-plugin`, 'Blink', { type: 'external' }]
     ]
   },
   {


### PR DESCRIPTION
Removes 22 sidebar entries from sidebarUserGuide that reference non-existent pages, causing VuePress build to fail with:

TypeError: Cannot read properties of undefined (reading 'match')`n
in SidebarLink.vue.

### Removed Integrations
BigCommerce, Drupal, Ecwid, Ghost, Grandnode, Nopcommerce, Odoo, Smartstore, Wix, Xenforo, Zapier

### Removed Plugins
Breez, Bringin, DynamicReports, LNDhubAPI, Nostr, VendorPay, PodServer, SideShift, TicketTailor, Trocador, Wabisabi

### Verification
Build succeeds after this fix.

Closes #1618