### PR TITLE
Document btcpay-host integration contract

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -291,6 +291,7 @@ const sidebarDevelopment = [
     children: [
       '/Development/',
       '/Development/LocalDevelopment',
+      '/Development/HostIntegration',
       ['/BTCPayServer/greenfield-development', 'Greenfield API Development'],
       {
         title: 'Plugins',

--- a/docs/Development/HostIntegration.md
+++ b/docs/Development/HostIntegration.md
@@ -47,12 +47,13 @@ A deployment can advertise any subset of the following commands:
 
 | Command              | Arguments                                       | Successful output                         | Enables                                                               |
 | -------------------- | ----------------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------- |
+| `env`                | None                                            | Deployment metadata as a JSON object      | Host integration discovery                                            |
 | `showauthorizedkeys` | None                                            | The authorized keys file as a JSON string | Reading SSH keys in **Server Settings > Services > SSH**              |
-| `setauthorizedkeys`  | The complete authorized keys file as argument 1 | Not used                                  | Updating SSH keys in **Server Settings > Services > SSH**             |
-| `changedomain`       | The new domain as argument 1                    | Not used                                  | Changing the domain from **Server Settings > Maintenance**            |
-| `update`             | None                                            | Not used                                  | Updating the deployment from **Server Settings > Maintenance**        |
-| `clean`              | None                                            | Not used                                  | Cleaning unused host resources from **Server Settings > Maintenance** |
-| `restart`            | None                                            | Not used                                  | Restarting the deployment from **Server Settings > Maintenance**      |
+| `setauthorizedkeys`  | The complete authorized keys file as argument 1 | Logs                                      | Updating SSH keys in **Server Settings > Services > SSH**             |
+| `changedomain`       | The new domain as argument 1                    | Logs                                      | Changing the domain from **Server Settings > Maintenance**            |
+| `update`             | None                                            | Logs                                      | Updating the deployment from **Server Settings > Maintenance**        |
+| `clean`              | None                                            | Logs                                      | Cleaning unused host resources from **Server Settings > Maintenance** |
+| `restart`            | None                                            | Logs                                      | Restarting the deployment from **Server Settings > Maintenance**      |
 
 The SSH service is available only when both `showauthorizedkeys` and `setauthorizedkeys` are
 advertised. Unknown command names in the `commands` array are ignored by BTCPay Server, so a

--- a/docs/Development/HostIntegration.md
+++ b/docs/Development/HostIntegration.md
@@ -84,5 +84,6 @@ Docker implementation and is not part of the `btcpay-host` interface.
 
 See the reference implementations in
 [BTCPay Server](https://github.com/btcpayserver/btcpayserver/pull/7511),
-[host environment discovery](https://github.com/btcpayserver/btcpayserver/pull/7543), and
+[host environment discovery](https://github.com/btcpayserver/btcpayserver/pull/7543),
+[host integration opt-in](https://github.com/btcpayserver/btcpayserver/pull/7554), and
 [btcpayserver-docker](https://github.com/btcpayserver/btcpayserver-docker/pull/1081).

--- a/docs/Development/HostIntegration.md
+++ b/docs/Development/HostIntegration.md
@@ -6,8 +6,9 @@ administration features that it supports without exposing general host access to
 Server.
 
 Host integration is disabled by default. Enable it with `btcpayhostenabled=true` in the
-configuration file or `BTCPAY_BTCPAYHOSTENABLED=true` in the environment. Providing a
-`btcpay-host` executable alone does not enable the integration.
+configuration file, `BTCPAY_BTCPAYHOSTENABLED=true` in the environment, or
+`--btcpayhostenabled true` on the command line. Providing a `btcpay-host` executable alone
+does not enable the integration.
 
 When host integration is disabled, unavailable, or does not advertise a feature, BTCPay
 Server hides the related Server Settings pages and actions.
@@ -20,7 +21,8 @@ btcpay-host <command> [arguments]
 ```
 
 The executable must be available to the BTCPay Server process. Its path can be overridden
-with the `btcpayhostexecutable` configuration setting.
+with the `btcpayhostexecutable` configuration setting or the `--btcpayhostexecutable`
+command-line option.
 
 ## Environment discovery
 

--- a/docs/Development/HostIntegration.md
+++ b/docs/Development/HostIntegration.md
@@ -5,8 +5,12 @@ BTCPay Server delegates deployment-specific administration to an executable name
 administration features that it supports without exposing general host access to BTCPay
 Server.
 
-Providing `btcpay-host` is optional. When it is unavailable or does not advertise a
-feature, BTCPay Server hides the related Server Settings pages and actions.
+Host integration is disabled by default. Enable it with `btcpayhostenabled=true` in the
+configuration file or `BTCPAY_BTCPAYHOSTENABLED=true` in the environment. Providing a
+`btcpay-host` executable alone does not enable the integration.
+
+When host integration is disabled, unavailable, or does not advertise a feature, BTCPay
+Server hides the related Server Settings pages and actions.
 
 BTCPay Server runs the executable directly and passes the command and its arguments as
 regular process arguments:

--- a/docs/Development/HostIntegration.md
+++ b/docs/Development/HostIntegration.md
@@ -1,0 +1,72 @@
+# Host integration
+
+BTCPay Server delegates deployment-specific administration to an executable named
+`btcpay-host`. A deployment can provide this executable to enable only the server
+administration features that it supports without exposing general host access to BTCPay
+Server.
+
+BTCPay Server runs the executable directly and passes the command and its arguments as
+regular process arguments:
+
+```bash
+btcpay-host <command> [arguments]
+```
+
+The executable must be available to the BTCPay Server process. Its path can be overridden
+with the `btcpayhostexecutable` configuration setting.
+
+## Environment discovery
+
+BTCPay Server runs `btcpay-host env` during startup. A successful call must exit with status
+`0` and write one JSON object to standard output:
+
+```json
+{
+  "deploymentType": "btcpayserver-docker",
+  "commands": ["changedomain", "update", "clean", "restart"]
+}
+```
+
+The properties are:
+
+- `deploymentType`: A stable identifier for the deployment implementation. BTCPay Server
+  includes it in the startup log.
+- `commands`: The commands supported by this deployment. BTCPay Server uses this list to
+  decide which administration features to expose.
+
+Invalid JSON, a nonzero exit status, or an unavailable executable disables the host-backed
+administration features. BTCPay Server performs discovery only during startup, so it must be
+restarted after the available commands change.
+
+## Commands
+
+A deployment can advertise any subset of the following commands:
+
+| Command              | Arguments                                       | Successful output                         | Enables                                                               |
+| -------------------- | ----------------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------- |
+| `showauthorizedkeys` | None                                            | The authorized keys file as a JSON string | Reading SSH keys in **Server Settings > Services > SSH**              |
+| `setauthorizedkeys`  | The complete authorized keys file as argument 1 | Not used                                  | Updating SSH keys in **Server Settings > Services > SSH**             |
+| `changedomain`       | The new domain as argument 1                    | Not used                                  | Changing the domain from **Server Settings > Maintenance**            |
+| `update`             | None                                            | Not used                                  | Updating the deployment from **Server Settings > Maintenance**        |
+| `clean`              | None                                            | Not used                                  | Cleaning unused host resources from **Server Settings > Maintenance** |
+| `restart`            | None                                            | Not used                                  | Restarting the deployment from **Server Settings > Maintenance**      |
+
+The SSH service is available only when both `showauthorizedkeys` and `setauthorizedkeys` are
+advertised. Unknown command names in the `commands` array are ignored by BTCPay Server, so a
+deployment can also expose commands for its own tools.
+
+Commands should exit with status `0` when accepted. On failure, they should return a nonzero
+status and write a diagnostic message to standard error. JSON-producing commands must reserve
+standard output for their documented response.
+
+## Security
+
+`btcpay-host` is a privileged boundary between the BTCPay Server application and its
+deployment. Implement only the required commands, validate every argument, and do not pass
+untrusted values through a shell. The account running BTCPay Server should not receive broader
+host access than these commands require.
+
+The official [Docker deployment](https://github.com/btcpayserver/btcpayserver-docker) forwards
+calls over SSH with a restricted key and a forced command. Its proxy serializes process
+arguments as a JSON array for transport over SSH. That transport format is specific to the
+Docker implementation and is not part of the `btcpay-host` interface.

--- a/docs/Development/HostIntegration.md
+++ b/docs/Development/HostIntegration.md
@@ -5,6 +5,9 @@ BTCPay Server delegates deployment-specific administration to an executable name
 administration features that it supports without exposing general host access to BTCPay
 Server.
 
+Providing `btcpay-host` is optional. When it is unavailable or does not advertise a
+feature, BTCPay Server hides the related Server Settings pages and actions.
+
 BTCPay Server runs the executable directly and passes the command and its arguments as
 regular process arguments:
 

--- a/docs/Development/HostIntegration.md
+++ b/docs/Development/HostIntegration.md
@@ -34,6 +34,9 @@ The properties are:
 - `commands`: The commands supported by this deployment. BTCPay Server uses this list to
   decide which administration features to expose.
 
+Deployments can include extra properties for their own metadata. BTCPay Server ignores
+properties it does not recognize.
+
 Invalid JSON, a nonzero exit status, or an unavailable executable disables the host-backed
 administration features. BTCPay Server performs discovery only during startup, so it must be
 restarted after the available commands change.
@@ -70,3 +73,8 @@ The official [Docker deployment](https://github.com/btcpayserver/btcpayserver-do
 calls over SSH with a restricted key and a forced command. Its proxy serializes process
 arguments as a JSON array for transport over SSH. That transport format is specific to the
 Docker implementation and is not part of the `btcpay-host` interface.
+
+See the reference implementations in
+[BTCPay Server](https://github.com/btcpayserver/btcpayserver/pull/7511),
+[host environment discovery](https://github.com/btcpayserver/btcpayserver/pull/7543), and
+[btcpayserver-docker](https://github.com/btcpayserver/btcpayserver-docker/pull/1081).


### PR DESCRIPTION
Documents how deployment providers can expose host administration features to BTCPay Server through the restricted `btcpay-host` interface.

The new development guide covers environment discovery, supported commands and arguments, output and exit-status expectations, capability refresh behavior, and the security boundary. It also distinguishes the general process interface from the Docker deployment's SSH transport.